### PR TITLE
Merge branch '20150827-bugfix-1724-intel_gpu_opengl_overlays' into development.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -33,6 +33,7 @@ include( CompilerVersion )
 include( UnitTest )
 include( CompilationFlags )
 include( AStyleUtils )
+include( ExternalDependencies )
 
 # Organize projects into folders
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )

--- a/source/Core/Castor3D/Src/OverlayRenderer.cpp
+++ b/source/Core/Castor3D/Src/OverlayRenderer.cpp
@@ -176,15 +176,8 @@ namespace Castor3D
 
 	uint32_t FillBuffers( OverlayCategory::VertexArray::const_iterator p_begin, size_t p_count, GeometryBuffers & p_buffers )
 	{
-		VertexBuffer & l_vtxBuffer = p_buffers.GetVertexBuffer();
-
-		if ( l_vtxBuffer.Bind() )
-		{
-			OverlayCategory::Vertex const & l_vertex = *p_begin;
-			l_vtxBuffer.Fill( reinterpret_cast< uint8_t const * >( &l_vertex ), p_count * sizeof( OverlayCategory::Vertex ), eBUFFER_ACCESS_TYPE_DYNAMIC, eBUFFER_ACCESS_NATURE_DRAW );
-			l_vtxBuffer.Unbind();
-		}
-
+		OverlayCategory::Vertex const & l_vertex = *p_begin;
+		p_buffers.GetVertexBuffer().Fill( reinterpret_cast< uint8_t const * >( &l_vertex ), p_count * sizeof( OverlayCategory::Vertex ), eBUFFER_ACCESS_TYPE_DYNAMIC, eBUFFER_ACCESS_NATURE_DRAW );
 		return p_count;
 	}
 

--- a/source/Importers/ASSIMPImporter/CMakeLists.txt
+++ b/source/Importers/ASSIMPImporter/CMakeLists.txt
@@ -21,7 +21,7 @@ if( ASSIMP_FOUND )
 
 	set( CastorBinsDependencies 
 		${CastorBinsDependencies}
-		AssimpImporter
+		${PROJECT_NAME}
 		PARENT_SCOPE
 	)
 
@@ -30,70 +30,20 @@ if( ASSIMP_FOUND )
     set( ASSIMP_VERSION_BUILD	0 )
 
 	add_target(
-		AssimpImporter
+		${PROJECT_NAME}
 		plugin
 		"Castor3D"
 		"${CastorMinLibraries};${ASSIMPLibraries}"
 	)
 
-	set_property( TARGET AssimpImporter PROPERTY FOLDER "Importers" )
+	set_property( TARGET ${PROJECT_NAME} PROPERTY FOLDER "Importers" )
 	set( Build "yes (version ${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}.${ASSIMP_VERSION_BUILD})" PARENT_SCOPE )
-	add_target_astyle( AssimpImporter ".h;.hpp;.inl;.cpp" )
+	add_target_astyle( ${PROJECT_NAME} ".h;.hpp;.inl;.cpp" )
 
 	if ( WIN32 )
 		# Preparing ASSIMP dll installation
-		set( ASSIMP_RELEASE_DIR )
-		if ( EXISTS ${ASSIMP_LIBRARY_RELEASE_DIR}/assimp.dll )
-			set( ASSIMP_RELEASE_DIR ${ASSIMP_LIBRARY_RELEASE_DIR} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_RELEASE_DIR}/../../bin/${PROJECTS_PLATFORM}/assimp.dll )
-			get_filename_component( ASSIMP_RELEASE_DIR ${ASSIMP_LIBRARY_RELEASE_DIR} PATH )
-			get_filename_component( ASSIMP_RELEASE_DIR ${ASSIMP_RELEASE_DIR} PATH )
-			set( ASSIMP_RELEASE_DIR ${ASSIMP_RELEASE_DIR}/bin/${PROJECTS_PLATFORM} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_RELEASE_DIR}/../bin/assimp.dll )
-			get_filename_component( ASSIMP_RELEASE_DIR ${ASSIMP_LIBRARY_RELEASE_DIR} PATH )
-			set( ASSIMP_RELEASE_DIR ${ASSIMP_RELEASE_DIR}/bin )
-		endif ()
-		install(
-			FILES ${ASSIMP_RELEASE_DIR}/assimp.dll
-			DESTINATION bin
-			CONFIGURATIONS Release
-			COMPONENT AssimpImporter
-		)
-		add_custom_command(
-			TARGET AssimpImporter
-			POST_BUILD
-			COMMAND if 1==$<CONFIG:Release>
-				${CMAKE_COMMAND} -E
-					copy_if_different
-					${ASSIMP_RELEASE_DIR}/assimp.dll
-					${PROJECTS_BINARIES_OUTPUT_DIR}/$<CONFIGURATION>/bin
-		)
-		set( ASSIMP_DEBUG_DIR )
-		if ( EXISTS ${ASSIMP_LIBRARY_DEBUG_DIR}/assimpD.dll )
-			set( ASSIMP_DEBUG_DIR ${ASSIMP_LIBRARY_DEBUG_DIR} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_DEBUG_DIR}/../../bin/${PROJECTS_PLATFORM}/assimpD.dll )
-			get_filename_component( ASSIMP_DEBUG_DIR ${ASSIMP_LIBRARY_DEBUG_DIR} PATH )
-			get_filename_component( ASSIMP_DEBUG_DIR ${ASSIMP_DEBUG_DIR} PATH )
-			set( ASSIMP_DEBUG_DIR ${ASSIMP_DEBUG_DIR}/bin/${PROJECTS_PLATFORM} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_DEBUG_DIR}/../bin/assimpD.dll )
-			get_filename_component( ASSIMP_DEBUG_DIR ${ASSIMP_LIBRARY_DEBUG_DIR} PATH )
-			set( ASSIMP_DEBUG_DIR ${ASSIMP_DEBUG_DIR}/bin )
-		endif ()
-		install(
-			FILES ${ASSIMP_DEBUG_DIR}/assimpD.dll
-			DESTINATION bin
-			CONFIGURATIONS Debug
-			COMPONENT AssimpImporter
-		)
-		add_custom_command(
-			TARGET AssimpImporter
-			POST_BUILD
-			COMMAND if 1==$<CONFIG:Debug>
-				${CMAKE_COMMAND} -E
-					copy_if_different
-					${ASSIMP_DEBUG_DIR}/assimpD.dll
-					${PROJECTS_BINARIES_OUTPUT_DIR}/$<CONFIGURATION>/bin
-		)
+		copy_dll( ${PROJECT_NAME} ${ASSIMP_LIBRARY_RELEASE} Release )
+		copy_dll( ${PROJECT_NAME} ${ASSIMP_LIBRARY_DEBUG} Debug )
 	elseif ( {${CASTOR_PACKAGE_DEB} )
 		set( CPACK_DEBIAN_PACKAGE_DEPENDS "libassimp3-dev, ${CPACK_DEBIAN_PACKAGE_DEPENDS}" )
 	endif ()

--- a/source/Importers/AssimpImporter/CMakeLists.txt
+++ b/source/Importers/AssimpImporter/CMakeLists.txt
@@ -21,7 +21,7 @@ if( ASSIMP_FOUND )
 
 	set( CastorBinsDependencies 
 		${CastorBinsDependencies}
-		AssimpImporter
+		${PROJECT_NAME}
 		PARENT_SCOPE
 	)
 
@@ -30,70 +30,20 @@ if( ASSIMP_FOUND )
     set( ASSIMP_VERSION_BUILD	0 )
 
 	add_target(
-		AssimpImporter
+		${PROJECT_NAME}
 		plugin
 		"Castor3D"
 		"${CastorMinLibraries};${ASSIMPLibraries}"
 	)
 
-	set_property( TARGET AssimpImporter PROPERTY FOLDER "Importers" )
+	set_property( TARGET ${PROJECT_NAME} PROPERTY FOLDER "Importers" )
 	set( Build "yes (version ${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}.${ASSIMP_VERSION_BUILD})" PARENT_SCOPE )
-	add_target_astyle( AssimpImporter ".h;.hpp;.inl;.cpp" )
+	add_target_astyle( ${PROJECT_NAME} ".h;.hpp;.inl;.cpp" )
 
 	if ( WIN32 )
 		# Preparing ASSIMP dll installation
-		set( ASSIMP_RELEASE_DIR )
-		if ( EXISTS ${ASSIMP_LIBRARY_RELEASE_DIR}/assimp.dll )
-			set( ASSIMP_RELEASE_DIR ${ASSIMP_LIBRARY_RELEASE_DIR} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_RELEASE_DIR}/../../bin/${PROJECTS_PLATFORM}/assimp.dll )
-			get_filename_component( ASSIMP_RELEASE_DIR ${ASSIMP_LIBRARY_RELEASE_DIR} PATH )
-			get_filename_component( ASSIMP_RELEASE_DIR ${ASSIMP_RELEASE_DIR} PATH )
-			set( ASSIMP_RELEASE_DIR ${ASSIMP_RELEASE_DIR}/bin/${PROJECTS_PLATFORM} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_RELEASE_DIR}/../bin/assimp.dll )
-			get_filename_component( ASSIMP_RELEASE_DIR ${ASSIMP_LIBRARY_RELEASE_DIR} PATH )
-			set( ASSIMP_RELEASE_DIR ${ASSIMP_RELEASE_DIR}/bin )
-		endif ()
-		install(
-			FILES ${ASSIMP_RELEASE_DIR}/assimp.dll
-			DESTINATION bin
-			CONFIGURATIONS Release
-			COMPONENT AssimpImporter
-		)
-		add_custom_command(
-			TARGET AssimpImporter
-			POST_BUILD
-			COMMAND if 1==$<CONFIG:Release>
-				${CMAKE_COMMAND} -E
-					copy_if_different
-					${ASSIMP_RELEASE_DIR}/assimp.dll
-					${PROJECTS_BINARIES_OUTPUT_DIR}/$<CONFIGURATION>/bin
-		)
-		set( ASSIMP_DEBUG_DIR )
-		if ( EXISTS ${ASSIMP_LIBRARY_DEBUG_DIR}/assimpD.dll )
-			set( ASSIMP_DEBUG_DIR ${ASSIMP_LIBRARY_DEBUG_DIR} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_DEBUG_DIR}/../../bin/${PROJECTS_PLATFORM}/assimpD.dll )
-			get_filename_component( ASSIMP_DEBUG_DIR ${ASSIMP_LIBRARY_DEBUG_DIR} PATH )
-			get_filename_component( ASSIMP_DEBUG_DIR ${ASSIMP_DEBUG_DIR} PATH )
-			set( ASSIMP_DEBUG_DIR ${ASSIMP_DEBUG_DIR}/bin/${PROJECTS_PLATFORM} )
-		elseif ( EXISTS ${ASSIMP_LIBRARY_DEBUG_DIR}/../bin/assimpD.dll )
-			get_filename_component( ASSIMP_DEBUG_DIR ${ASSIMP_LIBRARY_DEBUG_DIR} PATH )
-			set( ASSIMP_DEBUG_DIR ${ASSIMP_DEBUG_DIR}/bin )
-		endif ()
-		install(
-			FILES ${ASSIMP_DEBUG_DIR}/assimpD.dll
-			DESTINATION bin
-			CONFIGURATIONS Debug
-			COMPONENT AssimpImporter
-		)
-		add_custom_command(
-			TARGET AssimpImporter
-			POST_BUILD
-			COMMAND if 1==$<CONFIG:Debug>
-				${CMAKE_COMMAND} -E
-					copy_if_different
-					${ASSIMP_DEBUG_DIR}/assimpD.dll
-					${PROJECTS_BINARIES_OUTPUT_DIR}/$<CONFIGURATION>/bin
-		)
+		copy_dll( ${PROJECT_NAME} ${ASSIMP_LIBRARY_RELEASE} Release )
+		copy_dll( ${PROJECT_NAME} ${ASSIMP_LIBRARY_DEBUG} Debug )
 	elseif ( {${CASTOR_PACKAGE_DEB} )
 		set( CPACK_DEBIAN_PACKAGE_DEPENDS "libassimp3-dev, ${CPACK_DEBIAN_PACKAGE_DEPENDS}" )
 	endif ()

--- a/source/Renderers/Dx11RenderSystem/Src/Dx11OverlayRenderer.cpp
+++ b/source/Renderers/Dx11RenderSystem/Src/Dx11OverlayRenderer.cpp
@@ -13,7 +13,7 @@ namespace
 	static String OverlayVS =
 		cuT( "struct VtxInput\n" )
 		cuT( "{\n" )
-		cuT( "	uint4 Position: POSITION;\n" )
+		cuT( "	int2 Position: POSITION;\n" )
 		cuT( "	float2 TextureUV: TEXCOORD0;\n" )
 		cuT( "};\n" )
 		cuT( "struct VtxOutput\n" )
@@ -24,8 +24,7 @@ namespace
 		cuT( "VtxOutput mainVx( VtxInput p_input )\n" )
 		cuT( "{\n" )
 		cuT( "	VtxOutput l_output;\n" )
-		cuT( "	p_input.Position.w = 1.0f;\n" )
-		cuT( "	l_output.Position = mul( p_input.Position, c3d_mtxProjection );\n" )
+		cuT( "	l_output.Position = mul( int4( p_input.Position, 0.0, 1.0 ), c3d_mtxProjection );\n" )
 		cuT( "	l_output.TextureUV = p_input.TextureUV;\n" )
 		cuT( "	return l_output;\n" )
 		cuT( "}\n" );

--- a/source/Renderers/GlRenderSystem/Src/GlBufferBase.inl
+++ b/source/Renderers/GlRenderSystem/Src/GlBufferBase.inl
@@ -39,15 +39,7 @@ namespace GlRender
 	template< typename T >
 	bool GlBufferBase< T >::Initialise( T const * p_pBuffer, ptrdiff_t p_iSize, Castor3D::eBUFFER_ACCESS_TYPE p_eType, Castor3D::eBUFFER_ACCESS_NATURE p_eNature )
 	{
-		bool l_bResult = Bind();
-
-		if ( l_bResult )
-		{
-			l_bResult = Fill( p_pBuffer, p_iSize, p_eType, p_eNature );
-			Unbind();
-		}
-
-		return l_bResult;
+		return Fill( p_pBuffer, p_iSize, p_eType, p_eNature );
 	}
 
 	template< typename T >
@@ -70,7 +62,15 @@ namespace GlRender
 	template< typename T >
 	bool GlBufferBase< T >::Fill( T const * p_pBuffer, ptrdiff_t p_iSize, Castor3D::eBUFFER_ACCESS_TYPE p_eType, Castor3D::eBUFFER_ACCESS_NATURE p_eNature )
 	{
-		return m_gl.BufferData( m_eTarget, p_iSize * sizeof( T ), p_pBuffer, m_gl.GetBufferFlags( p_eNature | p_eType ) );
+		bool l_bResult = Bind();
+
+		if ( l_bResult )
+		{
+			m_gl.BufferData( m_eTarget, p_iSize * sizeof( T ), p_pBuffer, m_gl.GetBufferFlags( p_eNature | p_eType ) );
+			Unbind();
+		}
+
+		return l_bResult;
 	}
 
 	template< typename T >

--- a/source/Renderers/GlRenderSystem/Src/GlFrameVariableBuffer.cpp
+++ b/source/Renderers/GlRenderSystem/Src/GlFrameVariableBuffer.cpp
@@ -887,8 +887,8 @@ namespace GlRender
 				{
 					m_gl.GetActiveUniformBlockiv( l_pProgram->GetGlProgram(), m_iUniformBlockIndex, eGL_UNIFORM_BLOCK_DATA_SIZE, &m_iUniformBlockSize );
 					m_glBuffer.Create();
-					m_glBuffer.Bind();
 					m_glBuffer.Fill( NULL, m_iUniformBlockSize, eBUFFER_ACCESS_TYPE_DYNAMIC, eBUFFER_ACCESS_NATURE_DRAW );
+					m_glBuffer.Bind();
 					m_gl.BindBufferBase( eGL_BUFFER_TARGET_UNIFORM, m_uiIndex, m_glBuffer.GetGlIndex() );
 					m_gl.UniformBlockBinding( l_pProgram->GetGlProgram(), m_iUniformBlockIndex, m_uiIndex );
 					m_buffer.resize( m_iUniformBlockSize );

--- a/source/Renderers/GlRenderSystem/Src/GlGeometryBuffers.cpp
+++ b/source/Renderers/GlRenderSystem/Src/GlGeometryBuffers.cpp
@@ -61,7 +61,6 @@ namespace GlRender
 
 		if ( m_pMatrixBuffer )
 		{
-			m_gl.BindBuffer( eGL_BUFFER_TARGET_ARRAY, std::static_pointer_cast< GlMatrixBufferObject >( m_pMatrixBuffer->GetGpuBuffer() )->GetGlIndex() );
 			m_pMatrixBuffer->GetGpuBuffer()->Fill( m_pMatrixBuffer->data(), m_pMatrixBuffer->GetSize(), eBUFFER_ACCESS_TYPE_DYNAMIC, eBUFFER_ACCESS_NATURE_DRAW );
 		}
 

--- a/source/Renderers/GlRenderSystem/Src/GlOverlayRenderer.cpp
+++ b/source/Renderers/GlRenderSystem/Src/GlOverlayRenderer.cpp
@@ -58,7 +58,7 @@ ShaderProgramBaseSPtr GlOverlayRenderer::DoGetProgram( uint32_t p_uiFlags )
 		UBO_MATRIX( l_writer );
 
 		// Shader inputs
-		ATTRIBUTE( l_writer, IVec4, vertex );
+		ATTRIBUTE( l_writer, IVec2, vertex );
 		ATTRIBUTE( l_writer, Vec2, texture );
 
 		// Shader outputs
@@ -67,7 +67,7 @@ ShaderProgramBaseSPtr GlOverlayRenderer::DoGetProgram( uint32_t p_uiFlags )
 		l_writer.Implement_Function< void >( cuT( "main" ), [&]()
 		{
 			vtx_texture = texture;
-			BUILTIN( l_writer, Vec4, gl_Position ) = c3d_mtxProjection * vec4( vertex.x(), vertex.y(), vertex.z(), 1.0 );
+			BUILTIN( l_writer, Vec4, gl_Position ) = c3d_mtxProjection * vec4( vertex.x(), vertex.y(), 0.0, 1.0 );
 		} );
 
 		l_strVs = l_writer.Finalise();

--- a/source/Renderers/GlRenderSystem/Src/GlPackPixelBuffer.cpp
+++ b/source/Renderers/GlRenderSystem/Src/GlPackPixelBuffer.cpp
@@ -24,12 +24,9 @@ namespace GlRender
 
 	void GlPackPixelBuffer::Initialise()
 	{
-		Create();
-
-		if ( Bind() )
+		if ( Create() )
 		{
 			Fill( m_pPixels, m_uiPixelsSize );
-			Unbind();
 		}
 	}
 }

--- a/source/Renderers/GlRenderSystem/Src/GlShaderSource.cpp
+++ b/source/Renderers/GlRenderSystem/Src/GlShaderSource.cpp
@@ -454,6 +454,21 @@ namespace GlRender
 			m_stream << cuT( "EndPrimitive();" ) << std::endl;
 		}
 
+		Vec4 GlslWriter::Texture1D( Sampler1D const & p_sampler, Type const & p_value )
+		{
+			return WriteFunctionCall< Vec4 >( this, m_keywords->GetTexture1D(), p_sampler, p_value );
+		}
+
+		Vec4 GlslWriter::Texture2D( Sampler2D const & p_sampler, Type const & p_value )
+		{
+			return WriteFunctionCall< Vec4 >( this, m_keywords->GetTexture2D(), p_sampler, p_value );
+		}
+
+		Vec4 GlslWriter::Texture3D( Sampler3D const & p_sampler, Type const & p_value )
+		{
+			return WriteFunctionCall< Vec4 >( this, m_keywords->GetTexture3D(), p_sampler, p_value );
+		}
+
 		GlslWriter & GlslWriter::operator<<( Version const & p_rhs )
 		{
 			m_stream << m_keywords->GetVersion();
@@ -548,17 +563,17 @@ namespace GlRender
 
 		Vec4 texture1D( Sampler1D const & p_sampler, Type const & p_value )
 		{
-			return WriteFunctionCall< Vec4 >( p_sampler.m_writer, cuT( "texture1D" ), p_sampler, p_value );
+			return p_sampler.m_writer->Texture1D( p_sampler, p_value );
 		}
 
 		Vec4 texture2D( Sampler2D const & p_sampler, Type const & p_value )
 		{
-			return WriteFunctionCall< Vec4 >( p_sampler.m_writer, cuT( "texture2D" ), p_sampler, p_value );
+			return p_sampler.m_writer->Texture2D( p_sampler, p_value );
 		}
 
 		Vec4 texture3D( Sampler3D const & p_sampler, Type const & p_value )
 		{
-			return WriteFunctionCall< Vec4 >( p_sampler.m_writer, cuT( "texture3D" ), p_sampler, p_value );
+			return p_sampler.m_writer->Texture3D( p_sampler, p_value );
 		}
 
 		Vec2 reflect( Vec2 const & p_a, Type const & p_b )

--- a/source/Renderers/GlRenderSystem/Src/GlShaderSource.hpp
+++ b/source/Renderers/GlRenderSystem/Src/GlShaderSource.hpp
@@ -164,6 +164,11 @@ namespace GlRender
 			GlslWriter & m_writer;
 			Castor::String m_name;
 		};
+		
+		struct Sampler1D;
+		struct Sampler2D;
+		struct Sampler3D;
+		struct Vec4;
 
 		class GlslWriter
 		{
@@ -185,6 +190,9 @@ namespace GlRender
 			Ubo GetUbo( Castor::String const & p_name );
 			void EmitVertex();
 			void EndPrimitive();
+			Vec4 Texture1D( Sampler1D const & p_sampler, Type const & p_value );
+			Vec4 Texture2D( Sampler2D const & p_sampler, Type const & p_value );
+			Vec4 Texture3D( Sampler3D const & p_sampler, Type const & p_value );
 
 			template< typename RetType, typename FuncType, typename ... Params > inline void Implement_Function( Castor::String const & p_name, FuncType p_function, Params && ... p_params );
 			template< typename RetType > void Return( RetType const & p_return );

--- a/source/Renderers/GlRenderSystem/Src/GlUnpackPixelBuffer.cpp
+++ b/source/Renderers/GlRenderSystem/Src/GlUnpackPixelBuffer.cpp
@@ -22,12 +22,9 @@ namespace GlRender
 
 	void GlUnpackPixelBuffer::Initialise()
 	{
-		Create();
-
-		if ( Bind() )
+		if ( Create() )
 		{
 			Fill( NULL, m_uiPixelsSize );
-			Unbind();
 		}
 	}
 }


### PR DESCRIPTION
Corrected the bug, was due to CpuBuffer::Bind being called in order to Fill the buffer.

Since at that time we don't have an active VAO, the attrbitues binding fails.
To correct it, now GlBufferBase::Fill calls Bind/Unbind internally, without attributes binding.