### PR TITLE
Merge branch '20160211-bugfix-001783-text_overlay_no_font_crash' into development.

### DIFF
--- a/source/Core/Castor3D/Src/OverlayManager.cpp
+++ b/source/Core/Castor3D/Src/OverlayManager.cpp
@@ -208,7 +208,7 @@ namespace Castor3D
 
 		for ( auto l_it : m_elements )
 		{
-			if ( l_it.second->GetCategory()->GetType() == eOVERLAY_TYPE_TEXT )
+			if ( l_it.second->GetCategory()->GetType() == eOVERLAY_TYPE_TEXT && l_it.second->GetCategory()->IsVisible() )
 			{
 				l_it.second->GetTextOverlay()->LoadNewGlyphs();
 			}

--- a/source/Core/Castor3D/Src/SceneFileParser_Parsers.cpp
+++ b/source/Core/Castor3D/Src/SceneFileParser_Parsers.cpp
@@ -2831,7 +2831,26 @@ END_ATTRIBUTE_PUSH( eSECTION_TEXT_OVERLAY )
 IMPLEMENT_ATTRIBUTE_PARSER( Castor3D, Parser_OverlayEnd )
 {
 	SceneFileContextSPtr l_pContext = std::static_pointer_cast< SceneFileContext >( p_context );
-	l_pContext->pOverlay->SetVisible( true );
+
+	if ( l_pContext->pOverlay->GetType() == eOVERLAY_TYPE_TEXT )
+	{
+		auto l_textOverlay = l_pContext->pOverlay->GetTextOverlay();
+
+		if ( l_textOverlay->GetFontTexture() )
+		{
+			l_pContext->pOverlay->SetVisible( true );
+		}
+		else
+		{
+			l_pContext->pOverlay->SetVisible( false );
+			PARSING_ERROR( cuT( "TextOverlay's font has not been set, it will not be rendered" ) );
+		}
+	}
+	else
+	{
+		l_pContext->pOverlay->SetVisible( true );
+	}
+
 	l_pContext->pOverlay = l_pContext->pOverlay->GetParent();
 }
 END_ATTRIBUTE_POP()

--- a/source/Core/Castor3D/Src/TextOverlay.cpp
+++ b/source/Core/Castor3D/Src/TextOverlay.cpp
@@ -191,6 +191,13 @@ namespace Castor3D
 	void TextOverlay::LoadNewGlyphs()
 	{
 		FontTextureSPtr l_fontTexture = GetFontTexture();
+
+		if ( !l_fontTexture )
+		{
+			SetVisible( false );
+			CASTOR_EXCEPTION( cuT( "The TextOverlay [" ) + GetOverlayName() + cuT( "] has no FontTexture. Did you set its font?" ) );
+		}
+
 		FontSPtr l_font = l_fontTexture->GetFont();
 		std::vector< char32_t > l_new;
 

--- a/source/Core/CastorUtils/Src/FileParser.cpp
+++ b/source/Core/CastorUtils/Src/FileParser.cpp
@@ -567,7 +567,7 @@ namespace Castor
 
 	void FileParser::DoLeaveBlock()
 	{
-		if ( m_ignored )
+		if ( DoIsInIgnoredBlock() )
 		{
 			m_ignoreLevel--;
 
@@ -580,6 +580,7 @@ namespace Castor
 		}
 		else
 		{
+			m_ignored = false;
 			DoParseScriptBlockEnd();
 		}
 	}

--- a/source/Core/CastorUtils/Src/StringUtils.cpp
+++ b/source/Core/CastorUtils/Src/StringUtils.cpp
@@ -252,21 +252,7 @@ namespace Castor
 
 				if ( p_bLeft )
 				{
-					l_index = p_str.find_first_not_of( cuT( ' ' ) );
-
-					if ( l_index > 0 )
-					{
-						if ( l_index != String::npos )
-						{
-							p_str = p_str.substr( l_index, String::npos );
-						}
-						else
-						{
-							p_str.clear();
-						}
-					}
-
-					l_index = p_str.find_first_not_of( cuT( '\t' ) );
+					l_index = p_str.find_first_not_of( cuT( " \t" ) );
 
 					if ( l_index > 0 )
 					{
@@ -283,24 +269,10 @@ namespace Castor
 
 				if ( p_bRight && p_str.size() > 0 )
 				{
-					l_index = p_str.find_last_not_of( cuT( ' ' ) );
+					l_index = p_str.find_last_not_of( cuT( " \t" ) );
 
 					if ( l_index < p_str.size() - 1 )
 					{
-						if ( l_index != String::npos )
-						{
-							p_str = p_str.substr( 0, l_index + 1 );
-						}
-						else
-						{
-							p_str.clear();
-						}
-					}
-
-					if ( p_str.size() > 0 )
-					{
-						l_index = p_str.find_last_not_of( cuT( '\t' ) );
-
 						if ( l_index != String::npos )
 						{
 							p_str = p_str.substr( 0, l_index + 1 );


### PR DESCRIPTION
Castor won't crash anymore if TextOverlay doesn't have a font, it will just hide it, and report it in the log.