### PR TITLE
Merge branch '20160211-bugfix-001782-debug_overlays_in_scene_tree' into development.

### DIFF
--- a/source/Samples/CastorViewer/Src/MainFrame.cpp
+++ b/source/Samples/CastorViewer/Src/MainFrame.cpp
@@ -288,7 +288,7 @@ namespace CastorViewer
 		m_sceneObjectsList = new SceneObjectsList( m_propertiesContainer, m_sceneTabsContainer, wxDefaultPosition, wxDefaultSize );
 		m_sceneObjectsList->SetBackgroundColour( PANEL_BACKGROUND_COLOUR );
 		m_sceneObjectsList->SetForegroundColour( PANEL_FOREGROUND_COLOUR );
-		m_sceneTabsContainer->AddPage( m_sceneObjectsList, _( "Scenes" ), true );
+		m_sceneTabsContainer->AddPage( m_sceneObjectsList, _( "Scene" ), true );
 
 		m_materialsList = new MaterialsList( m_propertiesContainer, m_sceneTabsContainer, wxDefaultPosition, wxDefaultSize );
 		m_materialsList->SetBackgroundColour( PANEL_BACKGROUND_COLOUR );

--- a/source/Samples/GuiCommon/Src/SceneObjectsList.cpp
+++ b/source/Samples/GuiCommon/Src/SceneObjectsList.cpp
@@ -147,7 +147,7 @@ namespace GuiCommon
 
 			for ( auto && l_overlay : p_engine->GetOverlayManager() )
 			{
-				if ( l_overlay->GetOverlayName() != cuT( "DebugPanel" ) )
+				if ( l_overlay->GetOverlayName().find( cuT( "DebugPanel" ) ) != 0 )
 				{
 					switch ( l_overlay->GetType() )
 					{


### PR DESCRIPTION
Debug overlays are no longer shown in Scene Tree.