### PR TITLE
Merge branch '20160224-bugfix-00XXXX-reload_scene' into development.

### DIFF
--- a/source/Core/Castor3D/Src/BufferDeclaration.cpp
+++ b/source/Core/Castor3D/Src/BufferDeclaration.cpp
@@ -5,7 +5,7 @@ using namespace Castor;
 namespace Castor3D
 {
 	BufferDeclaration::BufferDeclaration()
-		: BufferDeclaration( NULL, 0 )
+		: BufferDeclaration( nullptr, 0 )
 	{
 	}
 

--- a/source/Core/Castor3D/Src/BufferElementGroup.cpp
+++ b/source/Core/Castor3D/Src/BufferElementGroup.cpp
@@ -7,7 +7,7 @@ using namespace Castor;
 namespace Castor3D
 {
 	BufferElementGroup::BufferElementGroup( uint8_t * p_buffer, uint32_t p_index )
-		:	m_pBuffer( NULL )
+		:	m_pBuffer( nullptr )
 		,	m_index( p_index )
 	{
 		LinkCoords( p_buffer );

--- a/source/Core/Castor3D/Src/BufferElementGroup.hpp
+++ b/source/Core/Castor3D/Src/BufferElementGroup.hpp
@@ -44,7 +44,7 @@ namespace Castor3D
 		 *\param[in]	p_buffer		Le tampon de données
 		 *\param[in]	p_index		L'indice du groupe
 		 */
-		C3D_API BufferElementGroup( uint8_t * p_buffer = NULL, uint32_t p_index = 0 );
+		C3D_API BufferElementGroup( uint8_t * p_buffer = nullptr, uint32_t p_index = 0 );
 		/**
 		 *\~english
 		 *\brief		Destructor

--- a/source/Core/Castor3D/Src/Camera.cpp
+++ b/source/Core/Castor3D/Src/Camera.cpp
@@ -246,7 +246,7 @@ namespace Castor3D
 
 	void Camera::EndRender()
 	{
-		GetScene()->GetEngine()->GetRenderSystem()->SetCurrentCamera( NULL );
+		GetScene()->GetEngine()->GetRenderSystem()->SetCurrentCamera( nullptr );
 	}
 
 	void Camera::Resize( uint32_t p_width, uint32_t p_height )

--- a/source/Core/Castor3D/Src/Context.cpp
+++ b/source/Core/Castor3D/Src/Context.cpp
@@ -22,11 +22,11 @@ namespace Castor3D
 {
 	Context::Context( RenderSystem & p_renderSystem, bool p_invertFinal )
 		: OwnedBy< RenderSystem >( p_renderSystem )
-		, m_window( NULL )
+		, m_window( nullptr )
 		, m_initialised( false )
 		, m_bMultiSampling( false )
 		, m_viewport( Viewport::Ortho( *GetRenderSystem()->GetEngine(), 0, 1, 0, 1, 0, 1 ) )
-		, m_declaration( NULL, 0 )
+		, m_declaration( nullptr, 0 )
 	{
 		real l_pBuffer[] =
 		{
@@ -120,7 +120,7 @@ namespace Castor3D
 		m_geometryBuffers.reset();
 		m_bMultiSampling = false;
 		m_renderTextureProgram.reset();
-		m_window = NULL;
+		m_window = nullptr;
 	}
 
 	void Context::SetCurrent()
@@ -131,7 +131,7 @@ namespace Castor3D
 
 	void Context::EndCurrent()
 	{
-		GetRenderSystem()->SetCurrentContext( NULL );
+		GetRenderSystem()->SetCurrentContext( nullptr );
 		DoEndCurrent();
 	}
 

--- a/source/Core/Castor3D/Src/CpuBuffer.hpp
+++ b/source/Core/Castor3D/Src/CpuBuffer.hpp
@@ -147,7 +147,7 @@ namespace Castor3D
 		 */
 		inline T * Lock( uint32_t p_offset, uint32_t p_count, uint32_t p_flags )
 		{
-			T * l_return = NULL;
+			T * l_return = nullptr;
 			GpuBufferSPtr l_pBuffer = GetGpuBuffer();
 
 			if ( l_pBuffer )
@@ -406,7 +406,7 @@ namespace Castor3D
 		 */
 		inline T const * data()const
 		{
-			return ( m_arrayData.size() ? &m_arrayData[0] : NULL );
+			return ( m_arrayData.size() ? &m_arrayData[0] : nullptr );
 		}
 		/**
 		 *\~english
@@ -418,7 +418,7 @@ namespace Castor3D
 		 */
 		inline T * data()
 		{
-			return ( m_arrayData.size() ? &m_arrayData[0] : NULL );
+			return ( m_arrayData.size() ? &m_arrayData[0] : nullptr );
 		}
 
 	protected:

--- a/source/Core/Castor3D/Src/Engine.cpp
+++ b/source/Core/Castor3D/Src/Engine.cpp
@@ -48,9 +48,10 @@ namespace Castor3D
 
 	Engine::Engine()
 		: Unique< Engine >( this )
-		, m_renderSystem( NULL )
+		, m_renderSystem( nullptr )
 		, m_cleaned( true )
 		, m_perObjectLighting( true )
+		, m_threaded( false )
 	{
 		std::locale::global( std::locale() );
 
@@ -109,7 +110,7 @@ namespace Castor3D
 			if ( l_plugin )
 			{
 				l_plugin->DestroyRenderSystem( m_renderSystem );
-				m_renderSystem = NULL;
+				m_renderSystem = nullptr;
 			}
 			else
 			{
@@ -122,6 +123,8 @@ namespace Castor3D
 
 	void Engine::Initialise( uint32_t p_wanted, bool p_threaded )
 	{
+		m_threaded = p_threaded;
+
 		if ( m_renderSystem )
 		{
 			m_targetManager->SetRenderSystem( m_renderSystem );
@@ -187,6 +190,12 @@ namespace Castor3D
 		if ( !IsCleaned() )
 		{
 			SetCleaned();
+
+			if ( m_threaded )
+			{
+				m_renderLoop->Pause();
+			}
+
 			m_listenerManager->Cleanup();
 			m_sceneManager->Cleanup();
 			m_depthStencilStateManager->Cleanup();
@@ -216,7 +225,6 @@ namespace Castor3D
 			m_windowManager->Cleanup();
 			m_techniqueManager->Cleanup();
 			m_renderLoop.reset();
-			m_renderSystem->Cleanup();
 
 			m_targetManager->Clear();
 			m_samplerManager->Clear();

--- a/source/Core/Castor3D/Src/Engine.hpp
+++ b/source/Core/Castor3D/Src/Engine.hpp
@@ -346,6 +346,16 @@ namespace Castor3D
 		 *\~french
 		 *\return		La boucle de rendu.
 		 */
+		inline bool HasRenderLoop()const
+		{
+			return m_renderLoop != nullptr;
+		}
+		/**
+		 *\~english
+		 *\return		The render loop.
+		 *\~french
+		 *\return		La boucle de rendu.
+		 */
 		inline RenderLoop const & GetRenderLoop()const
 		{
 			return *m_renderLoop;
@@ -382,6 +392,16 @@ namespace Castor3D
 		{
 			return m_perObjectLighting;
 		}
+		/**
+		 *\~english
+		 *\return		Tells if the engine uses an asynchronous render loop.
+		 *\~french
+		 *\return		Dit si le moteur utilise un boucle de rendu asynchrone.
+		 */
+		inline bool IsThreaded()
+		{
+			return m_threaded;
+		}
 
 	private:
 		void DoLoadCoreData();
@@ -397,6 +417,8 @@ namespace Castor3D
 		RenderSystem * m_renderSystem;
 		//!\~english Tells if engine is cleaned up	\~french Dit si le moteur est nettoyé
 		bool m_cleaned;
+		//!\~english Tells if engine uses an asynchronous render loop.	\~french Dit si le moteur utilise un boucle de rendu asynchrone.
+		bool m_threaded;
 		//!\~english Default blend states (no blend).	\~french Etats de blend par défaut (pas de blend).
 		BlendStateSPtr m_defaultBlendState;
 		//!\~english Default sampler.	\~french Le sampler par défaut.

--- a/source/Core/Castor3D/Src/FrameVariable.cpp
+++ b/source/Core/Castor3D/Src/FrameVariable.cpp
@@ -164,7 +164,7 @@ namespace Castor3D
 		p_object.m_name.clear();
 		p_object.m_occurences = 0;
 		p_object.m_strValue.clear();
-		p_object.m_program = NULL;
+		p_object.m_program = nullptr;
 	}
 
 	FrameVariable & FrameVariable::operator =( FrameVariable const & p_object )
@@ -187,7 +187,7 @@ namespace Castor3D
 			p_object.m_name.clear();
 			p_object.m_occurences = 0;
 			p_object.m_strValue.clear();
-			p_object.m_program = NULL;
+			p_object.m_program = nullptr;
 		}
 
 		return *this;

--- a/source/Core/Castor3D/Src/FrameVariable.inl
+++ b/source/Core/Castor3D/Src/FrameVariable.inl
@@ -30,7 +30,7 @@
 	template< typename T >
 	TFrameVariable< T >::TFrameVariable( ShaderProgram * p_program )
 		: FrameVariable( p_program )
-		, m_values( NULL )
+		, m_values( nullptr )
 		, m_bOwnBuffer( true )
 	{
 		// m_values initialised in child classes
@@ -39,7 +39,7 @@
 	template< typename T >
 	TFrameVariable< T >::TFrameVariable( ShaderProgram * p_program, uint32_t p_occurences )
 		: FrameVariable( p_program, p_occurences )
-		, m_values( NULL )
+		, m_values( nullptr )
 		, m_bOwnBuffer( true )
 	{
 		// m_values initialised in child classes
@@ -48,7 +48,7 @@
 	template< typename T >
 	TFrameVariable< T >::TFrameVariable( TFrameVariable< T > const & p_rVariable )
 		: FrameVariable( p_rVariable )
-		, m_values( NULL )
+		, m_values( nullptr )
 		, m_bOwnBuffer( p_rVariable.m_bOwnBuffer )
 	{
 		if ( p_rVariable.m_bOwnBuffer )
@@ -80,7 +80,7 @@
 			p_rVariable.m_strValue[i].clear();
 		}
 
-		p_rVariable.m_values = NULL;
+		p_rVariable.m_values = nullptr;
 	}
 
 	template< typename T >

--- a/source/Core/Castor3D/Src/Generator.cpp
+++ b/source/Core/Castor3D/Src/Generator.cpp
@@ -175,7 +175,7 @@ void Generator::ClearAllThreads()
 	std::for_each( m_arraySlaveThreads.begin(), m_arraySlaveThreads.end(), [&]( Thread *& p_pThread )
 	{
 		Generator::Thread * l_pThread = p_pThread;
-		p_pThread = NULL;
+		p_pThread = nullptr;
 
 		if ( l_pThread )
 		{
@@ -193,7 +193,7 @@ bool Generator::AllEnded()
 
 	for ( uint32_t i = 0; i < l_count && l_return; i++ )
 	{
-		l_return &= m_arraySlaveThreads[i] == NULL || m_arraySlaveThreads[i]->IsEnded();
+		l_return &= m_arraySlaveThreads[i] == nullptr || m_arraySlaveThreads[i]->IsEnded();
 	}
 
 	return l_return;

--- a/source/Core/Castor3D/Src/Manager.hpp
+++ b/source/Core/Castor3D/Src/Manager.hpp
@@ -33,7 +33,7 @@ namespace Castor3D
 {
 	static const xchar * INFO_MANAGER_CREATED_OBJECT = cuT( "Manager::Create - Created " );
 	static const xchar * WARNING_MANAGER_DUPLICATE_OBJECT = cuT( "Manager::Create - Duplicate " );
-	static const xchar * WARNING_MANAGER_NULL_OBJECT = cuT( "Manager::Insert - NULL " );
+	static const xchar * WARNING_MANAGER_NULL_OBJECT = cuT( "Manager::Insert - nullptr " );
 	/*!
 	\author 	Sylvain DOREMUS
 	\date 		04/02/2016

--- a/source/Core/Castor3D/Src/MatrixFrameVariable.inl
+++ b/source/Core/Castor3D/Src/MatrixFrameVariable.inl
@@ -404,8 +404,8 @@
 		:	TFrameVariable< T >( std::move( p_rVariable ) )
 		,	m_mtxValue( std::move( p_rVariable.m_mtxValue ) )
 	{
-		p_rVariable.m_values = NULL;
-		p_rVariable.m_mtxValue = NULL;
+		p_rVariable.m_values = nullptr;
+		p_rVariable.m_mtxValue = nullptr;
 	}
 
 	template< typename T, uint32_t Rows, uint32_t Columns >
@@ -425,8 +425,8 @@
 		{
 			delete [] m_mtxValue;
 			m_mtxValue	= std::move( p_rVariable.m_mtxValue );
-			p_rVariable.m_values = NULL;
-			p_rVariable.m_mtxValue = NULL;
+			p_rVariable.m_values = nullptr;
+			p_rVariable.m_mtxValue = nullptr;
 		}
 
 		return *this;

--- a/source/Core/Castor3D/Src/OverlayManager.hpp
+++ b/source/Core/Castor3D/Src/OverlayManager.hpp
@@ -124,7 +124,7 @@ namespace Castor3D
 		 *\remark		If an overlay with the given name already exists, no creation is done, the return is the existing overlay
 		 *\param[in]	p_type		The overlay type (panel, text ...)
 		 *\param[in]	p_name	The overlay name
-		 *\param[in]	p_parent	The parent overlay, NULL if none
+		 *\param[in]	p_parent	The parent overlay, nullptr if none
 		 *\param[in]	p_scene	The scene that holds the overlay
 		 *\return		The created overlay
 		 *\~french

--- a/source/Core/Castor3D/Src/PlatformWindowHandle.hpp
+++ b/source/Core/Castor3D/Src/PlatformWindowHandle.hpp
@@ -59,7 +59,7 @@ namespace Castor3D
 		IMswWindowHandle( IMswWindowHandle && p_handle )
 			: m_hWnd( std::move( p_handle.m_hWnd ) )
 		{
-			p_handle.m_hWnd = NULL;
+			p_handle.m_hWnd = nullptr;
 		}
 
 		IMswWindowHandle & operator =( IMswWindowHandle const & p_handle )
@@ -73,7 +73,7 @@ namespace Castor3D
 			if ( this != & p_handle )
 			{
 				m_hWnd = std::move( p_handle.m_hWnd );
-				p_handle.m_hWnd = NULL;
+				p_handle.m_hWnd = nullptr;
 			}
 
 			return * this;
@@ -85,7 +85,7 @@ namespace Castor3D
 
 		virtual operator bool()
 		{
-			return m_hWnd != NULL;
+			return m_hWnd != nullptr;
 		}
 
 		inline HWND GetHwnd()const
@@ -121,7 +121,7 @@ namespace Castor3D
 			, m_display( std::move( p_handle.m_display ) )
 		{
 			p_handle.m_drawable = None;
-			p_handle.m_display = NULL;
+			p_handle.m_display = nullptr;
 		}
 
 		IXWindowHandle & operator =( IXWindowHandle const & p_handle )
@@ -138,7 +138,7 @@ namespace Castor3D
 				m_drawable = std::move( p_handle.m_drawable );
 				m_display = std::move( p_handle.m_display );
 				p_handle.m_drawable = None;
-				p_handle.m_display = NULL;
+				p_handle.m_display = nullptr;
 			}
 
 			return * this;
@@ -150,7 +150,7 @@ namespace Castor3D
 
 		virtual operator bool()
 		{
-			return m_drawable != None && m_display != NULL;
+			return m_drawable != None && m_display != nullptr;
 		}
 
 		inline GLXDrawable GetDrawable()const

--- a/source/Core/Castor3D/Src/PluginManager.hpp
+++ b/source/Core/Castor3D/Src/PluginManager.hpp
@@ -101,11 +101,11 @@ namespace Castor3D
 		 *\~english
 		 *\brief		Retrieves a shader plugin for given shader language
 		 *\param[in]	p_eLanguage	The shader language
-		 *\return		\p NULL if not found
+		 *\return		\p nullptr if not found
 		 *\~french
 		 *\brief		Récupère un ShaderPlugin pour le langage donné
 		 *\param[in]	p_eLanguage	Le langage
-		 *\return		\p NULL si non trouvé
+		 *\return		\p nullptr si non trouvé
 		 */
 		C3D_API PluginStrMap GetPlugins( ePLUGIN_TYPE p_type );
 		/**

--- a/source/Core/Castor3D/Src/RenderLoop.cpp
+++ b/source/Core/Castor3D/Src/RenderLoop.cpp
@@ -40,6 +40,16 @@ namespace Castor3D
 		DoStartRendering();
 	}
 
+	void RenderLoop::Pause()
+	{
+		DoPause();
+	}
+
+	void RenderLoop::Resume()
+	{
+		DoResume();
+	}
+
 	void RenderLoop::RenderSyncFrame()
 	{
 		DoRenderSyncFrame();

--- a/source/Core/Castor3D/Src/RenderLoop.hpp
+++ b/source/Core/Castor3D/Src/RenderLoop.hpp
@@ -67,12 +67,30 @@ namespace Castor3D
 		/**
 		 *\~english
 		 *\brief		Renders one frame.
-		 *\remarks		Use only with a synchronous render loop.
+		 *\remarks		Use only with a synchronous render loop, or when the render loop is paused.
 		 *\~french
 		 *\brief		Dessine une image.
-		 *\remark		A utiliser uniquement avec une boucle de rendu synchrone.
+		 *\remark		A utiliser uniquement avec une boucle de rendu synchrone, ou quand la boucle de rendu est en pause.
 		 */
 		C3D_API void RenderSyncFrame();
+		/**
+		 *\~english
+		 *\brief		Pauses the render loop.
+		 *\remarks		Use only with a synchronous render loop.
+		 *\~french
+		 *\brief		Met la boucle de rendu en pause.
+		 *\remark		A utiliser uniquement avec une boucle de rendu synchrone.
+		 */
+		C3D_API void Pause();
+		/**
+		 *\~english
+		 *\brief		Resumes the render loop.
+		 *\remarks		Use only with a synchronous render loop.
+		 *\~french
+		 *\brief		Relance la boucle de rendu.
+		 *\remark		A utiliser uniquement avec une boucle de rendu synchrone.
+		 */
+		C3D_API void Resume();
 		/**
 		 *\~english
 		 *\brief		Ends the render.
@@ -154,6 +172,20 @@ namespace Castor3D
 		 *\brief		Rend une image, uniquement hors de la boucle de rendu.
 		 */
 		C3D_API virtual void DoRenderSyncFrame() = 0;
+		/**
+		 *\~english
+		 *\brief		Pauses the render loop.
+		 *\~french
+		 *\brief		Met la boucle de rendu en pause.
+		 */
+		C3D_API virtual void DoPause() = 0;
+		/**
+		 *\~english
+		 *\brief		Resumes the render loop.
+		 *\~french
+		 *\brief		Redémarre la boucle de rendu.
+		 */
+		C3D_API virtual void DoResume() = 0;
 		/**
 		 *\~english
 		 *\brief		Ends the render, cleans up engine.

--- a/source/Core/Castor3D/Src/RenderLoopAsync.hpp
+++ b/source/Core/Castor3D/Src/RenderLoopAsync.hpp
@@ -83,6 +83,17 @@ namespace Castor3D
 		C3D_API bool IsRendering()const;
 		/**
 		 *\~english
+		 *\brief		Retrieves the render paused status.
+		 *\remark		Thread-safe.
+		 *\return		\p true if paused.
+		 *\~french
+		 *\brief		Récupère le statut de rendu en pause.
+		 *\remark		Thread-safe.
+		 *\return		\p true si en pause.
+		 */
+		C3D_API bool IsPaused()const;
+		/**
+		 *\~english
 		 *\brief		Thread-safe
 		 *\return		\p true if the render loop is interrupted.
 		 *\~french
@@ -112,6 +123,14 @@ namespace Castor3D
 		 */
 		C3D_API virtual void DoRenderSyncFrame();
 		/**
+		 *\copydoc		Castor3D::RenderLoop::DoPause
+		 */
+		C3D_API virtual void DoPause();
+		/**
+		 *\copydoc		Castor3D::RenderLoop::DoResume
+		 */
+		C3D_API virtual void DoResume();
+		/**
 		 *\copydoc		Castor3D::RenderLoop::DoEndRendering
 		 */
 		C3D_API virtual void DoEndRendering();
@@ -138,6 +157,10 @@ namespace Castor3D
 		std::atomic_bool m_ended;
 		//!\~english Tells if render is running.	\~french Dit si le rendu est en cours.
 		std::atomic_bool m_rendering;
+		//!\~english Tells the frame render is ended.	\~french Dit si le rendu de la frame courante est terminé.
+		std::atomic_bool m_frameEnded;
+		//!\~english Tells if render is paused.	\~french Dit si le rendu est en pause.
+		std::atomic_bool m_paused;
 		//!\~english Tells if render context is to be created.	\~french Dit si le contexte de rendu est à créer.
 		std::atomic_bool m_createContext;
 		//!\~english Tells if render context is created.	\~french Dit si le contexte de rendu est créé.

--- a/source/Core/Castor3D/Src/RenderLoopSync.cpp
+++ b/source/Core/Castor3D/Src/RenderLoopSync.cpp
@@ -8,6 +8,8 @@ namespace Castor3D
 {
 	static const char * CALL_START_RENDERING = "Can't call StartRendering in a synchronous render loop";
 	static const char * CALL_END_RENDERING = "Can't call EndRendering in a synchronous render loop";
+	static const char * CALL_PAUSE_RENDERING = "Can't call Pause in a synchronous render loop";
+	static const char * CALL_RESUME_RENDERING = "Can't call Resume in a synchronous render loop";
 	static const char * RLS_UNKNOWN_EXCEPTION = "Unknown exception";
 
 	RenderLoopSync::RenderLoopSync( Engine & p_engine, RenderSystem * p_renderSystem, uint32_t p_wantedFPS )
@@ -20,6 +22,7 @@ namespace Castor3D
 	{
 		// No render loop so we clean the render system ourselves with that single call.
 		DoRenderFrame();
+		m_renderSystem->Cleanup();
 	}
 
 	void RenderLoopSync::DoStartRendering()
@@ -51,6 +54,16 @@ namespace Castor3D
 				m_active = false;
 			}
 		}
+	}
+
+	void RenderLoopSync::DoPause()
+	{
+		CASTOR_EXCEPTION( CALL_PAUSE_RENDERING );
+	}
+
+	void RenderLoopSync::DoResume()
+	{
+		CASTOR_EXCEPTION( CALL_RESUME_RENDERING );
 	}
 
 	void RenderLoopSync::DoEndRendering()

--- a/source/Core/Castor3D/Src/RenderLoopSync.hpp
+++ b/source/Core/Castor3D/Src/RenderLoopSync.hpp
@@ -66,6 +66,14 @@ namespace Castor3D
 		 */
 		C3D_API virtual void DoRenderSyncFrame();
 		/**
+		 *\copydoc		Castor3D::RenderLoop::DoPause
+		 */
+		C3D_API virtual void DoPause();
+		/**
+		 *\copydoc		Castor3D::RenderLoop::DoResume
+		 */
+		C3D_API virtual void DoResume();
+		/**
 		 *\copydoc		Castor3D::RenderLoop::DoEndRendering
 		 */
 		C3D_API virtual void DoEndRendering();

--- a/source/Core/Castor3D/Src/RenderSystem.cpp
+++ b/source/Core/Castor3D/Src/RenderSystem.cpp
@@ -51,13 +51,13 @@ namespace Castor3D
 
 	void RenderSystem::Cleanup()
 	{
-		DoCleanup();
-
 		if ( m_mainContext )
 		{
 			m_mainContext->Cleanup();
 			m_mainContext.reset();
 		}
+
+		DoCleanup();
 
 #if !defined( NDEBUG )
 
@@ -87,7 +87,7 @@ namespace Castor3D
 
 	Scene * RenderSystem::GetTopScene()
 	{
-		Scene * l_return = NULL;
+		Scene * l_return = nullptr;
 
 		if ( m_stackScenes.size() )
 		{

--- a/source/Core/Castor3D/Src/RenderSystem.hpp
+++ b/source/Core/Castor3D/Src/RenderSystem.hpp
@@ -148,10 +148,10 @@ namespace Castor3D
 		/**
 		 *\~english
 		 *\brief		Retrieves the top scene from the stack
-		 *\return		The scene, NULL if the stack is void
+		 *\return		The scene, nullptr if the stack is void
 		 *\~french
 		 *\brief		Récupère la scène du haut de la pile
-		 *\return		La scène, NULL si la pile est vide
+		 *\return		La scène, nullptr si la pile est vide
 		 */
 		C3D_API Scene * GetTopScene();
 		/**

--- a/source/Core/Castor3D/Src/RendererPlugin.cpp
+++ b/source/Core/Castor3D/Src/RendererPlugin.cpp
@@ -71,7 +71,7 @@ namespace Castor3D
 
 	RenderSystem * RendererPlugin::CreateRenderSystem( Engine * p_engine )
 	{
-		RenderSystem * l_return = NULL;
+		RenderSystem * l_return = nullptr;
 
 		if ( m_pfnCreateRenderSystem )
 		{

--- a/source/Core/Castor3D/Src/SceneFileParser_Parsers.cpp
+++ b/source/Core/Castor3D/Src/SceneFileParser_Parsers.cpp
@@ -1519,7 +1519,7 @@ IMPLEMENT_ATTRIBUTE_PARSER( Castor3D, Parser_MeshDivide )
 	SceneFileContextSPtr l_pContext = std::static_pointer_cast< SceneFileContext >( p_context );
 	Engine * l_pEngine = l_pContext->m_pParser->GetEngine();
 	DividerPluginSPtr l_pPlugin;
-	Subdivider * l_pDivider = NULL;
+	Subdivider * l_pDivider = nullptr;
 
 	if ( l_pContext->pMesh )
 	{

--- a/source/Core/Castor3D/Src/SceneNode.hpp
+++ b/source/Core/Castor3D/Src/SceneNode.hpp
@@ -329,14 +329,14 @@ namespace Castor3D
 		 *\param[out]	p_distance	Receives the distance of the met geometry
 		 *\param[out]	p_nearestFace	Receives the face of the met geometry
 		 *\param[out]	p_nearestSubmesh	Receives the submesh of the met geometry
-		 *\return		The geometry, NULL if none
+		 *\return		The geometry, nullptr if none
 		 *\~french
 		 *\brief		Récupère la géométrie la plus proche de ce noeud et de ses enfants, qui sera touchée par le rayon
 		 *\param[in]	p_ray		Le rayon
 		 *\param[out]	p_distance	Reçoit la distance de la géométrie rencontrée
 		 *\param[out]	p_nearestFace	Reçoit la face dans la géométrie rencontrée
 		 *\param[out]	p_nearestSubmesh	Reçoit le submesh de la géométrie rencontrée
-		 *\return		La géométrie, NULL si aucune
+		 *\return		La géométrie, nullptr si aucune
 		 */
 		C3D_API GeometrySPtr GetNearestGeometry( Ray * p_ray, real & p_distance, FaceSPtr * p_nearestFace, SubmeshSPtr * p_nearestSubmesh );
 		/**
@@ -594,11 +594,11 @@ namespace Castor3D
 		 *\~english
 		 *\brief		Retrieves the child with given name
 		 *\param[in]	p_name	The child name
-		 *\return		The value, NULL if not found
+		 *\return		The value, nullptr if not found
 		 *\~french
 		 *\brief		Récupère l'enfant avec le nom donné
 		 *\param[in]	p_name	Le nom de l'enfant
-		 *\return		La valeur, NULL si non trouvé
+		 *\return		La valeur, nullptr si non trouvé
 		 */
 		inline SceneNodeSPtr GetChild( Castor::String const & p_name )
 		{

--- a/source/Core/Castor3D/Src/Submesh.cpp
+++ b/source/Core/Castor3D/Src/Submesh.cpp
@@ -201,7 +201,7 @@ namespace Castor3D
 
 		if ( l_return && !l_pos.empty() )
 		{
-			stVERTEX_GROUP l_group = { uint32_t( l_pos.size() / 3 ), l_pos.data(), l_nml.data(), l_tan.data(), NULL, l_tex.data(), NULL };
+			stVERTEX_GROUP l_group = { uint32_t( l_pos.size() / 3 ), l_pos.data(), l_nml.data(), l_tan.data(), nullptr, l_tex.data(), nullptr };
 			p_obj.AddPoints( l_group );
 			p_obj.AddFaceGroup( l_faces.data(), uint32_t( l_faces.size() ) );
 		}

--- a/source/Core/CastorUtils/Src/Aligned.cpp
+++ b/source/Core/CastorUtils/Src/Aligned.cpp
@@ -41,7 +41,7 @@ namespace Castor
 {
 	void * AlignedAlloc( size_t p_alignment, size_t p_size )
 	{
-		void * l_mem = NULL;
+		void * l_mem = nullptr;
 		CU_ALIGNED_ALLOC( l_mem, p_alignment, p_size );
 		return l_mem;
 	}

--- a/source/Core/CastorUtils/Src/Aligned.hpp
+++ b/source/Core/CastorUtils/Src/Aligned.hpp
@@ -35,12 +35,12 @@ namespace Castor
 	 *\brief		Allocates aligned memory.
 	 *\param[in]	p_alignment	The alignment value, must be a power of two.
 	 *\param[in]	p_size		The wanted size.
-	 *\return		The allocated memory, NULL on error.
+	 *\return		The allocated memory, nullptr on error.
 	 *\~french
 	 *\brief		Alloue de la mémoire alignée.
 	 *\param[in]	p_alignment	La valeur d'alignement, doit être une puissance de deux.
 	 *\param[in]	p_size		La taille désirée.
-	 *\return		La mémoire allouée, NULL en cas d'erreur.
+	 *\return		La mémoire allouée, nullptr en cas d'erreur.
 	 */
 	CU_API void * AlignedAlloc( size_t p_alignment, size_t p_size );
 	/**
@@ -57,12 +57,12 @@ namespace Castor
 	 *\brief		Allocates aligned memory.
 	 *\param[in]	p_alignment	The alignment value, must be a power of two.
 	 *\param[in]	p_size		The wanted size.
-	 *\return		The allocated memory, NULL on error.
+	 *\return		The allocated memory, nullptr on error.
 	 *\~french
 	 *\brief		Alloue de la mémoire alignée.
 	 *\param[in]	p_alignment	La valeur d'alignement, doit être une puissance de deux.
 	 *\param[in]	p_size		La taille désirée.
-	 *\return		La mémoire allouée, NULL en cas d'erreur.
+	 *\return		La mémoire allouée, nullptr en cas d'erreur.
 	 */
 	template< typename T >
 	T * AlignedAlloc( size_t p_alignment, size_t p_size )

--- a/source/Core/CastorUtils/Src/ColourComponent.hpp
+++ b/source/Core/CastorUtils/Src/ColourComponent.hpp
@@ -48,7 +48,7 @@ namespace Castor
 		 *\brief		Constructeur par recopie
 		 *\param[in]	p_object	L'objet à copier
 		 */
-		ColourComponent()	: m_pfComponent( NULL ) {}
+		ColourComponent()	: m_pfComponent( nullptr ) {}
 
 	public:
 		/**

--- a/source/Core/CastorUtils/Src/Coords.inl
+++ b/source/Core/CastorUtils/Src/Coords.inl
@@ -89,7 +89,7 @@ namespace Castor
 
 	template< typename T, uint32_t Count >
 	Coords< T, Count >::Coords()
-		: m_coords( NULL )
+		: m_coords( nullptr )
 	{
 	}
 
@@ -107,10 +107,10 @@ namespace Castor
 
 	template< typename T, uint32_t Count >
 	Coords< T, Count >::Coords( Coords< T, Count > && p_pt )
-		: m_coords( NULL )
+		: m_coords( nullptr )
 	{
 		m_coords = std::move( p_pt.m_coords );
-		p_pt.m_coords = NULL;
+		p_pt.m_coords = nullptr;
 	}
 
 	template< typename T, uint32_t Count >
@@ -131,7 +131,7 @@ namespace Castor
 		if ( this != &p_pt )
 		{
 			m_coords = std::move( p_pt.m_coords );
-			p_pt.m_coords = NULL;
+			p_pt.m_coords = nullptr;
 		}
 
 		return *this;

--- a/source/Core/CastorUtils/Src/Debug.cpp
+++ b/source/Core/CastorUtils/Src/Debug.cpp
@@ -118,7 +118,7 @@ namespace Castor
 				const int MaxFnNameLen( 255 );
 
 				void * l_backTrace[CALLS_TO_CAPTURE - CALLS_TO_SKIP];
-				unsigned int l_num( ::RtlCaptureStackBackTrace( CALLS_TO_SKIP, CALLS_TO_CAPTURE - CALLS_TO_SKIP, l_backTrace, NULL ) );
+				unsigned int l_num( ::RtlCaptureStackBackTrace( CALLS_TO_SKIP, CALLS_TO_CAPTURE - CALLS_TO_SKIP, l_backTrace, nullptr ) );
 
 				::HANDLE l_process( ::GetCurrentProcess() );
 				p_stream << "CALL STACK:" << std::endl;
@@ -133,7 +133,7 @@ namespace Castor
 
 					if ( !SymbolsInitialised )
 					{
-						SymbolsInitialised = ::SymInitialize( l_process, NULL, TRUE ) == TRUE;
+						SymbolsInitialised = ::SymInitialize( l_process, nullptr, TRUE ) == TRUE;
 					}
 
 					if ( SymbolsInitialised )

--- a/source/Core/CastorUtils/Src/DynamicLibrary.cpp
+++ b/source/Core/CastorUtils/Src/DynamicLibrary.cpp
@@ -12,13 +12,13 @@
 namespace Castor
 {
 	DynamicLibrary::DynamicLibrary()throw()
-		:	m_pLibrary( NULL	)
+		:	m_pLibrary( nullptr	)
 		,	m_pathLibrary(	)
 	{
 	}
 
 	DynamicLibrary::DynamicLibrary( DynamicLibrary const & p_lib )throw()
-		:	m_pLibrary( NULL	)
+		:	m_pLibrary( nullptr	)
 		,	m_pathLibrary(	)
 	{
 		if ( p_lib.m_pLibrary )
@@ -31,7 +31,7 @@ namespace Castor
 		:	m_pLibrary( std::move( p_lib.m_pLibrary )	)
 		,	m_pathLibrary( std::move( p_lib.m_pathLibrary )	)
 	{
-		p_lib.m_pLibrary = NULL;
+		p_lib.m_pLibrary = nullptr;
 		p_lib.m_pathLibrary.clear();
 	}
 
@@ -58,7 +58,7 @@ namespace Castor
 		{
 			m_pLibrary		= std::move( p_lib.m_pLibrary );
 			m_pathLibrary	= std::move( p_lib.m_pathLibrary );
-			p_lib.m_pLibrary = NULL;
+			p_lib.m_pLibrary = nullptr;
 			p_lib.m_pathLibrary.clear();
 		}
 
@@ -91,7 +91,7 @@ namespace Castor
 			catch ( ... )
 			{
 				Logger::LogError( std::string( "Can't load dynamic library at [" ) + l_name + std::string( "]" ) );
-				m_pLibrary = NULL;
+				m_pLibrary = nullptr;
 			}
 
 			if ( !m_pLibrary )
@@ -112,18 +112,18 @@ namespace Castor
 			catch ( ... )
 			{
 				Logger::LogError( std::string( "Can't load dynamic library at [" ) + l_name + std::string( "]" ) );
-				m_pLibrary = NULL;
+				m_pLibrary = nullptr;
 			}
 
 #endif
 		}
 
-		return m_pLibrary != NULL;
+		return m_pLibrary != nullptr;
 	}
 
 	void * DynamicLibrary::DoGetFunction( String const & p_name )throw()
 	{
-		void * l_return = NULL;
+		void * l_return = nullptr;
 
 		if ( m_pLibrary )
 		{
@@ -140,7 +140,7 @@ namespace Castor
 			}
 			catch ( ... )
 			{
-				l_return = NULL;
+				l_return = nullptr;
 				Logger::LogError( std::string( "Can't load function [" ) + l_name + std::string( "]" ) );
 			}
 
@@ -174,7 +174,7 @@ namespace Castor
 			}
 
 #endif
-			m_pLibrary = NULL;
+			m_pLibrary = nullptr;
 		}
 	}
 }

--- a/source/Core/CastorUtils/Src/DynamicLibrary.hpp
+++ b/source/Core/CastorUtils/Src/DynamicLibrary.hpp
@@ -174,7 +174,7 @@ namespace Castor
 		bool GetFunction( FuncType & p_pfnFunction, String const & p_name )throw()
 		{
 			p_pfnFunction = reinterpret_cast< FuncType >( DoGetFunction( p_name ) );
-			return p_pfnFunction != NULL;
+			return p_pfnFunction != nullptr;
 		}
 		/**
 		 *\~english
@@ -186,7 +186,7 @@ namespace Castor
 		 */
 		inline bool IsOpen()const
 		{
-			return m_pLibrary != NULL;
+			return m_pLibrary != nullptr;
 		}
 		/**
 		 *\~english

--- a/source/Core/CastorUtils/Src/File.cpp
+++ b/source/Core/CastorUtils/Src/File.cpp
@@ -83,7 +83,7 @@ namespace Castor
 
 			DIR * l_dir;
 
-			if ( ( l_dir = opendir( string::string_cast< char >( p_folderPath ).c_str() ) ) == NULL )
+			if ( ( l_dir = opendir( string::string_cast< char >( p_folderPath ).c_str() ) ) == nullptr )
 			{
 				switch ( errno )
 				{
@@ -127,7 +127,7 @@ namespace Castor
 				l_return = true;
 				dirent * l_dirent;
 
-				while ( l_return && ( l_dirent = readdir( l_dir ) ) != NULL )
+				while ( l_return && ( l_dirent = readdir( l_dir ) ) != nullptr )
 				{
 					String l_name = string::string_cast< xchar >( l_dirent->d_name );
 
@@ -226,14 +226,14 @@ namespace Castor
 	bool FOpen( FILE *& p_pFile, char const * p_pszPath, char const * p_pszMode )
 	{
 		p_pFile = fopen( p_pszPath, p_pszMode );
-		return p_pFile != NULL;
+		return p_pFile != nullptr;
 	}
 
 #	if !defined( _WIN32 )
 	bool FOpen64( FILE *& p_pFile, char const * p_pszPath, char const * p_pszMode )
 	{
 		p_pFile = fopen64( p_pszPath, p_pszMode );
-		return p_pFile != NULL;
+		return p_pFile != nullptr;
 	}
 
 	bool FSeek( FILE * p_pFile, int64_t p_i64Offset, int p_iOrigin )
@@ -249,7 +249,7 @@ namespace Castor
 	bool FOpen64( FILE *& p_pFile, char const * p_pszPath, char const * p_pszMode )
 	{
 		p_pFile = fopen( p_pszPath, p_pszMode );
-		return p_pFile != NULL;
+		return p_pFile != nullptr;
 	}
 
 	bool FSeek( FILE * p_pFile, int64_t p_i64Offset, int p_iOrigin )
@@ -271,7 +271,7 @@ namespace Castor
 		,	m_strFileFullPath( p_strFileName	)
 		,	m_ullCursor( 0	)
 		,	m_ullLength( 0	)
-		,	m_pFile( NULL	)
+		,	m_pFile( nullptr	)
 		,	m_bOwnFile( true	)
 	{
 		REQUIRE( ! p_strFileName.empty() );
@@ -353,7 +353,7 @@ namespace Castor
 
 	File::~File()
 	{
-		if ( m_pFile != NULL && m_bOwnFile )
+		if ( m_pFile != nullptr && m_bOwnFile )
 		{
 			fclose( m_pFile );
 		}
@@ -533,7 +533,7 @@ namespace Castor
 #if defined( _WIN32 )
 
 		xchar l_pPath[FILENAME_MAX];
-		DWORD dwResult = GetModuleFileName( NULL, l_pPath, _countof( l_pPath ) );
+		DWORD dwResult = GetModuleFileName( nullptr, l_pPath, _countof( l_pPath ) );
 
 		if ( dwResult != 0 )
 		{
@@ -568,7 +568,7 @@ namespace Castor
 #if defined( _WIN32 )
 
 		xchar l_path[FILENAME_MAX];
-		HRESULT l_hr = SHGetFolderPath( NULL, CSIDL_PROFILE, NULL, 0, l_path );
+		HRESULT l_hr = SHGetFolderPath( nullptr, CSIDL_PROFILE, nullptr, 0, l_path );
 
 		if ( SUCCEEDED( l_hr ) )
 		{

--- a/source/Core/CastorUtils/Src/FixedGrowingSizeMarkedMemoryData.hpp
+++ b/source/Core/CastorUtils/Src/FixedGrowingSizeMarkedMemoryData.hpp
@@ -60,9 +60,9 @@ namespace Castor
 		{
 			m_step = p_count;
 			m_total = 0;
-			m_free = NULL;
+			m_free = nullptr;
 			m_freeIndex = m_free;
-			m_buffers = NULL;
+			m_buffers = nullptr;
 			m_buffersEnd = m_buffers;
 			DoCreateBuffer();
 		}
@@ -106,11 +106,11 @@ namespace Castor
 		 *\~english
 		 *\brief		Gives the address an available chunk.
 		 *\remarks		Set the marked byte to "Allocated" state.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Donne un chunk mémoire disponible.
 		 *\remarks		Met l'octet de marquage dans l'état "Alloué".
-		 *\return		NULL s'il n'y a plus de place disponible, l'adresse mémoire sinon.
+		 *\return		nullptr s'il n'y a plus de place disponible, l'adresse mémoire sinon.
 		 */
 		Object * Allocate()noexcept
 		{
@@ -122,7 +122,7 @@ namespace Castor
 			if ( m_freeIndex == m_free )
 			{
 				ReportError< ePOOL_ERROR_TYPE_COMMON_OUT_OF_MEMORY >( Namer::Name );
-				return NULL;
+				return nullptr;
 			}
 
 			uint8_t * space = *--m_freeIndex;
@@ -134,7 +134,7 @@ namespace Castor
 		 *\brief		Frees the given memory.
 		 *\remarks		Checks if the given address comes from the pool.
 		 *\param[in]	p_space	The memory to free.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Libère la mémoire donnée.
 		 *\remarks		Vérifie si la mémoire fait bien partie du pool.
@@ -200,7 +200,7 @@ namespace Castor
 			m_buffers = reinterpret_cast< buffer * >( realloc( m_buffers, ( count + 1 ) * sizeof( buffer ) ) );
 			m_buffersEnd = m_buffers + count;
 			m_buffersEnd->m_data = new uint8_t[m_step * ( sizeof( Object ) + 1 )];
-			m_buffersEnd->m_end = NULL;
+			m_buffersEnd->m_end = nullptr;
 			uint8_t * buffer = m_buffersEnd->m_data;
 			m_free = reinterpret_cast< uint8_t ** >( realloc( m_free, m_total * sizeof( uint8_t * ) ) );
 			m_freeEnd = m_free + m_total;
@@ -222,22 +222,22 @@ namespace Castor
 		struct buffer
 		{
 			//!\~english The buffer.	\~french Le tampon.
-			uint8_t * m_data = NULL;
+			uint8_t * m_data = nullptr;
 			//!\~english Pointer to the buffer's end.	\~french Pointeur sur la fin du tampon.
-			uint8_t * m_end = NULL;
+			uint8_t * m_end = nullptr;
 		};
 		//!\~english The buffers.	\~french Les tampons.
-		buffer * m_buffers = NULL;
+		buffer * m_buffers = nullptr;
 		//!\~english Pointer to the buffers' end.	\~french Pointeur sur la fin des tampons.
-		buffer * m_buffersEnd = NULL;
+		buffer * m_buffersEnd = nullptr;
 		//!\~english The free chunks.	\~french Les chunks libres.
-		uint8_t ** m_free = NULL;
+		uint8_t ** m_free = nullptr;
 		//!\~english The free chunks' end.	\~french La fin des chunks libres.
-		uint8_t ** m_freeEnd = NULL;
+		uint8_t ** m_freeEnd = nullptr;
 		//!\~english The last allocated chunk.	\~french Le dernier chunk alloué.
-		uint8_t ** m_freeIndex = NULL;
+		uint8_t ** m_freeIndex = nullptr;
 		//!\~english The allocated object size	\~french La taille d'un objet alloué.
-		size_t m_objectSize = NULL;
+		size_t m_objectSize = nullptr;
 		//!\~english The size increment.	\~french L'incrément de taille.
 		size_t m_step = 0;
 		//!\~english The total allocated size.	\~french La taille totale allouée.

--- a/source/Core/CastorUtils/Src/FixedGrowingSizeMemoryData.hpp
+++ b/source/Core/CastorUtils/Src/FixedGrowingSizeMemoryData.hpp
@@ -56,9 +56,9 @@ namespace Castor
 		{
 			m_step = p_count;
 			m_total = 0;
-			m_free = NULL;
+			m_free = nullptr;
 			m_freeIndex = m_free;
-			m_buffers = NULL;
+			m_buffers = nullptr;
 			m_buffersEnd = m_buffers;
 			DoCreateBuffer();
 		}
@@ -82,18 +82,18 @@ namespace Castor
 				MemoryAllocator::Deallocate( buffer->m_data );
 			}
 
-			m_free = NULL;
-			m_buffers = NULL;
+			m_free = nullptr;
+			m_buffers = nullptr;
 			m_freeIndex = m_free;
 			m_buffersEnd = m_buffers;
 		}
 		/**
 		 *\~english
 		 *\brief		Gives the address an available chunk.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Donne un chunk mémoire disponible.
-		 *\return		NULL s'il n'y a plus de place disponible, l'adresse mémoire sinon.
+		 *\return		nullptr s'il n'y a plus de place disponible, l'adresse mémoire sinon.
 		 */
 		Object * Allocate()noexcept
 		{
@@ -105,7 +105,7 @@ namespace Castor
 			if ( m_freeIndex == m_free )
 			{
 				ReportError< ePOOL_ERROR_TYPE_COMMON_OUT_OF_MEMORY >( Namer::Name );
-				return NULL;
+				return nullptr;
 			}
 
 			return *--m_freeIndex;
@@ -115,7 +115,7 @@ namespace Castor
 		 *\brief		Frees the given memory.
 		 *\remarks		Checks if the given address comes from the pool.
 		 *\param[in]	p_space	The memory to free.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Libère la mémoire donnée.
 		 *\remarks		Vérifie si la mémoire fait bien partie du pool.
@@ -163,7 +163,7 @@ namespace Castor
 			m_buffers = reinterpret_cast< buffer * >( realloc( m_buffers, ( count + 1 ) * sizeof( buffer ) ) );
 			m_buffersEnd = m_buffers + count;
 			m_buffersEnd->m_data = MemoryAllocator::Allocate( m_step * sizeof( Object ) );
-			m_buffersEnd->m_end = NULL;
+			m_buffersEnd->m_end = nullptr;
 			auto buffer = m_buffersEnd->m_data;
 			m_free = reinterpret_cast< Object ** >( realloc( m_free, m_total * sizeof( Object * ) ) );
 			m_freeEnd = m_free + m_total;
@@ -183,20 +183,20 @@ namespace Castor
 		struct buffer
 		{
 			//!\~english The buffer.	\~french Le tampon.
-			uint8_t * m_data = NULL;
+			uint8_t * m_data = nullptr;
 			//!\~english Pointer to the buffer's end.	\~french Pointeur sur la fin du tampon.
-			uint8_t * m_end = NULL;
+			uint8_t * m_end = nullptr;
 		};
 		//!\~english The buffers.	\~french Les tampons.
-		buffer * m_buffers = NULL;
+		buffer * m_buffers = nullptr;
 		//!\~english Pointer to the buffers' end.	\~french Pointeur sur la fin des tampons.
-		buffer * m_buffersEnd = NULL;
+		buffer * m_buffersEnd = nullptr;
 		//!\~english The free chunks.	\~french Les chunks libres.
-		Object ** m_free = NULL;
+		Object ** m_free = nullptr;
 		//!\~english The free chunks' end.	\~french La fin des chunks libres.
-		Object ** m_freeEnd = NULL;
+		Object ** m_freeEnd = nullptr;
 		//!\~english The las allocated chunk.	\~french Le dernier chunk alloué.
-		Object ** m_freeIndex = NULL;
+		Object ** m_freeIndex = nullptr;
 		//!\~english The size increment.	\~french L'incrément de taille.
 		size_t m_step = 0;
 		//!\~english The total allocated size.	\~french La taille totale allouée.

--- a/source/Core/CastorUtils/Src/FixedSizeMarkedMemoryData.hpp
+++ b/source/Core/CastorUtils/Src/FixedSizeMarkedMemoryData.hpp
@@ -101,8 +101,8 @@ namespace Castor
 
 			delete [] m_free;
 			delete [] m_buffer;
-			m_free = NULL;
-			m_buffer = NULL;
+			m_free = nullptr;
+			m_buffer = nullptr;
 			m_freeIndex = m_free;
 			m_bufferEnd = m_buffer;
 		}
@@ -110,18 +110,18 @@ namespace Castor
 		 *\~english
 		 *\brief		Gives the address an available chunk.
 		 *\remarks		Set the marked byte to "Allocated" state.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Donne un chunk mémoire disponible.
 		 *\remarks		Met l'octet de marquage dans l'état "Alloué".
-		 *\return		NULL s'il n'y a plus de place disponible, l'adresse mémoire sinon.
+		 *\return		nullptr s'il n'y a plus de place disponible, l'adresse mémoire sinon.
 		 */
 		Object * Allocate()noexcept
 		{
 			if ( m_freeIndex == m_free )
 			{
 				ReportError< ePOOL_ERROR_TYPE_COMMON_OUT_OF_MEMORY >( Namer::Name );
-				return NULL;
+				return nullptr;
 			}
 
 			uint8_t * l_space = *--m_freeIndex;
@@ -134,7 +134,7 @@ namespace Castor
 		 *\remarks		Checks if the given address comes from the pool, and if it has been allocated by the pool, via the marked byte.
 		 *\remarks		Set the marked byte to "Free" state.
 		 *\param[in]	p_space	The memory to free.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Libère la mémoire donnée.
 		 *\remarks		Vérifie si la mémoire fait bien partie du pool, et si elle a bien été allouée par le pool, via l'octet de marquage.
@@ -185,15 +185,15 @@ namespace Castor
 
 	private:
 		//!\~english The buffer.	\~french Le tampon.
-		uint8_t * m_buffer = NULL;
+		uint8_t * m_buffer = nullptr;
 		//!\~english Pointer to the buffer's end.	\~french Pointeur sur la fin du tampon.
-		uint8_t * m_bufferEnd = NULL;
+		uint8_t * m_bufferEnd = nullptr;
 		//!\~english The free chunks.	\~french Les chunks libres.
-		uint8_t ** m_free = NULL;
+		uint8_t ** m_free = nullptr;
 		//!\~english The free chunks' end.	\~french La fin des chunks libres.
-		uint8_t ** m_freeEnd = NULL;
+		uint8_t ** m_freeEnd = nullptr;
 		//!\~english The last allocated chunk.	\~french Le dernier chunk alloué.
-		uint8_t ** m_freeIndex = NULL;
+		uint8_t ** m_freeIndex = nullptr;
 		//!\~english The total pool capacity.	\~french Le nombre total possible d'éléments.
 		size_t m_total = 0;
 	};

--- a/source/Core/CastorUtils/Src/FixedSizeMemoryData.hpp
+++ b/source/Core/CastorUtils/Src/FixedSizeMemoryData.hpp
@@ -82,25 +82,25 @@ namespace Castor
 
 			delete [] m_free;
 			MemoryAllocator::Deallocate( m_buffer );
-			m_free = NULL;
-			m_buffer = NULL;
+			m_free = nullptr;
+			m_buffer = nullptr;
 			m_freeIndex = m_free;
 			m_bufferEnd = m_buffer;
 		}
 		/**
 		 *\~english
 		 *\brief		Gives the address an available chunk.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Donne un chunk mémoire disponible.
-		 *\return		NULL s'il n'y a plus de place disponible, l'adresse mémoire sinon.
+		 *\return		nullptr s'il n'y a plus de place disponible, l'adresse mémoire sinon.
 		 */
 		Object * Allocate()noexcept
 		{
 			if ( m_freeIndex == m_free )
 			{
 				ReportError< ePOOL_ERROR_TYPE_COMMON_OUT_OF_MEMORY >( Namer::Name );
-				return NULL;
+				return nullptr;
 			}
 
 			return *--m_freeIndex;
@@ -110,7 +110,7 @@ namespace Castor
 		 *\brief		Frees the given memory.
 		 *\remarks		Checks if the given address comes from the pool.
 		 *\param[in]	p_space	The memory to free.
-		 *\return		NULL if no memory available, the memory address if not.
+		 *\return		nullptr if no memory available, the memory address if not.
 		 *\~french
 		 *\brief		Libère la mémoire donnée.
 		 *\remarks		Vérifie si la mémoire fait bien partie du pool.
@@ -144,15 +144,15 @@ namespace Castor
 
 	private:
 		//!\~english The buffer.	\~french Le tampon.
-		uint8_t * m_buffer = NULL;
+		uint8_t * m_buffer = nullptr;
 		//!\~english Pointer to the buffer's end.	\~french Pointeur sur la fin du tampon.
-		uint8_t * m_bufferEnd = NULL;
+		uint8_t * m_bufferEnd = nullptr;
 		//!\~english The free chunks.	\~french Les chunks libres.
-		Object ** m_free = NULL;
+		Object ** m_free = nullptr;
 		//!\~english The free chunks' end.	\~french La fin des chunks libres.
-		Object ** m_freeEnd = NULL;
+		Object ** m_freeEnd = nullptr;
 		//!\~english The las allocated chunk.	\~french Le dernier chunk alloué.
-		Object ** m_freeIndex = NULL;
+		Object ** m_freeIndex = nullptr;
 		//!\~english The total pool capacity.	\~french Le nombre total possible d'éléments.
 		size_t m_total = 0;
 	};

--- a/source/Core/CastorUtils/Src/Font.cpp
+++ b/source/Core/CastorUtils/Src/Font.cpp
@@ -129,8 +129,8 @@ namespace Castor
 			SFreeTypeFontImpl( Path const & p_pathFile, uint32_t p_height )
 				: m_height( p_height )
 				, m_path( p_pathFile )
-				, m_library( NULL )
-				, m_face( NULL )
+				, m_library( nullptr )
+				, m_face( nullptr )
 			{
 			}
 
@@ -150,8 +150,8 @@ namespace Castor
 			{
 				CHECK_FT_ERR( FT_Done_Face, m_face );
 				CHECK_FT_ERR( FT_Done_FreeType, m_library );
-				m_library = NULL;
-				m_face = NULL;
+				m_library = nullptr;
+				m_face = nullptr;
 			}
 
 			virtual void LoadGlyph( Glyph & p_glyph )

--- a/source/Core/CastorUtils/Src/FontManager.cpp
+++ b/source/Core/CastorUtils/Src/FontManager.cpp
@@ -13,7 +13,7 @@ namespace Castor
 	{
 		static const xchar * INFO_MANAGER_CREATED_OBJECT = cuT( "Manager::Create - Created " );
 		static const xchar * WARNING_MANAGER_DUPLICATE_OBJECT = cuT( "Manager::Create - Duplicate " );
-		static const xchar * WARNING_MANAGER_NULL_OBJECT = cuT( "Manager::Insert - NULL " );
+		static const xchar * WARNING_MANAGER_NULL_OBJECT = cuT( "Manager::Insert - nullptr " );
 	}
 
 	FontManager::BinaryLoader::BinaryLoader()

--- a/source/Core/CastorUtils/Src/Image.cpp
+++ b/source/Core/CastorUtils/Src/Image.cpp
@@ -79,7 +79,7 @@ namespace Castor
 		}
 
 		ePIXEL_FORMAT l_ePF = ePIXEL_FORMAT_R8G8B8;
-		FIBITMAP * l_pImage = NULL;
+		FIBITMAP * l_pImage = nullptr;
 		int l_iFlags = BMP_DEFAULT;
 		FREE_IMAGE_FORMAT l_fif = FreeImage_GetFileType( string::string_cast< char >( p_path ).c_str(), 0 );
 
@@ -104,7 +104,7 @@ namespace Castor
 			BinaryFile l_file( p_path, File::eOPEN_MODE_READ | File::eOPEN_MODE_BINARY );
 			FreeImageIO l_fiIo;
 			l_fiIo.read_proc = ReadProc;
-			l_fiIo.write_proc = NULL;
+			l_fiIo.write_proc = nullptr;
 			l_fiIo.seek_proc = SeekProc;
 			l_fiIo.tell_proc = TellProc;
 			l_pImage = FreeImage_LoadFromHandle( l_fif, & l_fiIo, fi_handle( & l_file ), l_iFlags );
@@ -167,7 +167,7 @@ namespace Castor
 	bool Image::BinaryLoader::operator()( Image const & p_image, Path const & p_path )
 	{
 		bool l_return = false;
-		FIBITMAP * l_pImage = NULL;
+		FIBITMAP * l_pImage = nullptr;
 		Size const & l_size = p_image.GetDimensions();
 		int32_t l_w = int32_t( l_size.width() );
 		int32_t l_h = int32_t( l_size.height() );
@@ -313,7 +313,7 @@ namespace Castor
 
 		if ( p_size != l_size )
 		{
-			FIBITMAP * l_pImage = NULL;
+			FIBITMAP * l_pImage = nullptr;
 			int32_t l_w = int32_t( l_size.width() );
 			int32_t l_h = int32_t( l_size.height() );
 			ePIXEL_FORMAT l_ePF = GetPixelFormat();

--- a/source/Core/CastorUtils/Src/Image.hpp
+++ b/source/Core/CastorUtils/Src/Image.hpp
@@ -120,7 +120,7 @@ namespace Castor
 		 *\param[in]	p_buffer		Un buffer de pixels
 		 *\param[in]	p_eBufferFormat	Le format des pixels du buffer
 		 */
-		CU_API Image( String const & p_name, Size const & p_ptSize, ePIXEL_FORMAT p_ePixelFormat = ePIXEL_FORMAT_A8R8G8B8, uint8_t const * p_buffer = NULL, ePIXEL_FORMAT p_eBufferFormat = ePIXEL_FORMAT_A8R8G8B8 );
+		CU_API Image( String const & p_name, Size const & p_ptSize, ePIXEL_FORMAT p_ePixelFormat = ePIXEL_FORMAT_A8R8G8B8, uint8_t const * p_buffer = nullptr, ePIXEL_FORMAT p_eBufferFormat = ePIXEL_FORMAT_A8R8G8B8 );
 		/**
 		 *\~english
 		 *\brief		Creates the image with given params
@@ -147,7 +147,7 @@ namespace Castor
 		 *\param[in]	p_buffer		Un buffer de pixels
 		 */
 		template< ePIXEL_FORMAT PFSrc, ePIXEL_FORMAT PFDst >
-		Image( String const & p_name, Size const & p_ptSize, uint8_t const * p_buffer = NULL )
+		Image( String const & p_name, Size const & p_ptSize, uint8_t const * p_buffer = nullptr )
 			: Resource< Image > ( p_name )
 			, m_pBuffer( std::make_shared< PxBuffer< PFDst > >( p_ptSize, p_buffer, PFSrc ) )
 		{

--- a/source/Core/CastorUtils/Src/ImageManager.cpp
+++ b/source/Core/CastorUtils/Src/ImageManager.cpp
@@ -13,7 +13,7 @@ namespace Castor
 	{
 		static const xchar * INFO_MANAGER_CREATED_OBJECT = cuT( "Manager::Create - Created " );
 		static const xchar * WARNING_MANAGER_DUPLICATE_OBJECT = cuT( "Manager::Create - Duplicate " );
-		static const xchar * WARNING_MANAGER_NULL_OBJECT = cuT( "Manager::Insert - NULL " );
+		static const xchar * WARNING_MANAGER_NULL_OBJECT = cuT( "Manager::Insert - nullptr " );
 	}
 
 	ImageManager::BinaryLoader::BinaryLoader()

--- a/source/Core/CastorUtils/Src/Logger.cpp
+++ b/source/Core/CastorUtils/Src/Logger.cpp
@@ -132,12 +132,12 @@ namespace Castor
 		}
 	};
 
-	Logger * Logger::m_singleton = NULL;
+	Logger * Logger::m_singleton = nullptr;
 	bool Logger::m_ownInstance = true;
 	uint32_t Logger::m_counter = 0;
 
 	Logger::Logger()
-		: m_impl( NULL )
+		: m_impl( nullptr )
 	{
 		std::unique_lock< std::mutex > lock( m_mutex );
 		m_headers[ELogType_DEBUG] = cuT( "***DEBUG*** " );
@@ -168,7 +168,7 @@ namespace Castor
 		{
 			m_impl->Cleanup();
 			delete m_impl;
-			m_impl = NULL;
+			m_impl = nullptr;
 		}
 	}
 
@@ -229,7 +229,7 @@ namespace Castor
 		{
 			m_counter--;
 			delete m_singleton;
-			m_singleton = NULL;
+			m_singleton = nullptr;
 		}
 	}
 

--- a/source/Core/CastorUtils/Src/LoggerConsole.cpp
+++ b/source/Core/CastorUtils/Src/LoggerConsole.cpp
@@ -19,7 +19,7 @@ namespace Castor
 		CMsvcConsoleInfo()
 			: m_oldCodePage( 0 )
 			, m_screenBuffer( INVALID_HANDLE_VALUE )
-			, m_oldInfos( NULL )
+			, m_oldInfos( nullptr )
 			, m_allocated( false )
 			, m_console( false )
 		{
@@ -106,7 +106,7 @@ namespace Castor
 				if ( ::GetConsoleScreenBufferInfo( m_screenBuffer, &csbiInfo ) )
 				{
 					csbiInfo.dwCursorPosition.X = 0;
-					::WriteConsole( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, NULL );
+					::WriteConsole( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, nullptr );
 					SHORT offsetY = SHORT( 1 + written / csbiInfo.dwSize.X );
 
 					if ( ( csbiInfo.dwSize.Y - offsetY ) <= csbiInfo.dwCursorPosition.Y )
@@ -127,7 +127,7 @@ namespace Castor
 						fill.Attributes = 0;
 						fill.Char.AsciiChar = char( ' ' );
 						// Scroll
-						::ScrollConsoleScreenBuffer( m_screenBuffer, &scrollRect, NULL, coordDest, &fill );
+						::ScrollConsoleScreenBuffer( m_screenBuffer, &scrollRect, nullptr, coordDest, &fill );
 					}
 					else
 					{
@@ -140,14 +140,14 @@ namespace Castor
 			}
 			else
 			{
-				::WriteConsole( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, NULL );
+				::WriteConsole( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, nullptr );
 			}
 		}
 
 	private:
 		void DoInitialiseConsole()
 		{
-			m_screenBuffer = ::CreateConsoleScreenBuffer( GENERIC_WRITE | GENERIC_READ, 0, NULL, CONSOLE_TEXTMODE_BUFFER, NULL );
+			m_screenBuffer = ::CreateConsoleScreenBuffer( GENERIC_WRITE | GENERIC_READ, 0, nullptr, CONSOLE_TEXTMODE_BUFFER, nullptr );
 
 			if ( m_screenBuffer != INVALID_HANDLE_VALUE && ::SetConsoleActiveScreenBuffer( m_screenBuffer ) )
 			{
@@ -168,13 +168,13 @@ namespace Castor
 					if ( !::SetCurrentConsoleFontEx( m_screenBuffer, FALSE, &newInfos ) )
 					{
 						delete m_oldInfos;
-						m_oldInfos = NULL;
+						m_oldInfos = nullptr;
 					}
 				}
 				else
 				{
 					delete m_oldInfos;
-					m_oldInfos = NULL;
+					m_oldInfos = nullptr;
 				}
 
 				COORD coord = { 160, 9999 };
@@ -302,7 +302,7 @@ namespace Castor
 				if ( ::GetConsoleScreenBufferInfo( m_screenBuffer, &csbiInfo ) )
 				{
 					csbiInfo.dwCursorPosition.X = 0;
-					::WriteConsole( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, NULL );
+					::WriteConsole( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, nullptr );
 					SHORT offsetY = SHORT( 1 + written / csbiInfo.dwSize.X );
 
 					if ( ( csbiInfo.dwSize.Y - offsetY ) <= csbiInfo.dwCursorPosition.Y )
@@ -323,7 +323,7 @@ namespace Castor
 						fill.Attributes = 0;
 						fill.Char.AsciiChar = char( ' ' );
 						// Scroll
-						::ScrollConsoleScreenBuffer( m_screenBuffer, &scrollRect, NULL, coordDest, &fill );
+						::ScrollConsoleScreenBuffer( m_screenBuffer, &scrollRect, nullptr, coordDest, &fill );
 					}
 					else
 					{
@@ -336,14 +336,14 @@ namespace Castor
 			}
 			else
 			{
-				::WriteConsoleA( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, NULL );
+				::WriteConsoleA( m_screenBuffer, toLog.c_str(), DWORD( toLog.size() ), &written, nullptr );
 			}
 		}
 
 	private:
 		void DoInitialiseConsole()
 		{
-			m_screenBuffer = ::CreateConsoleScreenBuffer( GENERIC_WRITE | GENERIC_READ, 0, NULL, CONSOLE_TEXTMODE_BUFFER, NULL );
+			m_screenBuffer = ::CreateConsoleScreenBuffer( GENERIC_WRITE | GENERIC_READ, 0, nullptr, CONSOLE_TEXTMODE_BUFFER, nullptr );
 
 			if ( m_screenBuffer != INVALID_HANDLE_VALUE && ::SetConsoleActiveScreenBuffer( m_screenBuffer ) )
 			{

--- a/source/Core/CastorUtils/Src/LoggerImpl.cpp
+++ b/source/Core/CastorUtils/Src/LoggerImpl.cpp
@@ -129,7 +129,7 @@ namespace Castor
 
 				if ( !l_text.empty() )
 				{
-					FILE * l_file = NULL;
+					FILE * l_file = nullptr;
 					FOpen( l_file, string::string_cast< char >( m_logFilePath[i++] ).c_str(), "a" );
 
 					if ( l_file )

--- a/source/Core/CastorUtils/Src/Matrix.hpp
+++ b/source/Core/CastorUtils/Src/Matrix.hpp
@@ -70,7 +70,7 @@ namespace Castor
 			: m_data( p_rhs.m_data )
 			, m_ownCoords( p_rhs.m_ownCoords )
 		{
-			p_rhs.m_data = NULL;
+			p_rhs.m_data = nullptr;
 			p_rhs.m_ownCoords = true;
 		}
 		/**
@@ -105,7 +105,7 @@ namespace Castor
 
 				m_data = p_rhs.m_data;
 				m_ownCoords = p_rhs.m_ownCoords;
-				p_rhs.m_data = NULL;
+				p_rhs.m_data = nullptr;
 				p_rhs.m_ownCoords = true;
 			}
 
@@ -124,7 +124,7 @@ namespace Castor
 			if ( m_ownCoords )
 			{
 				delete [] m_data;
-				m_data = NULL;
+				m_data = nullptr;
 			}
 
 			m_data = p_data;
@@ -188,7 +188,7 @@ namespace Castor
 			: m_data( p_rhs.m_data )
 			, m_ownCoords( p_rhs.m_ownCoords )
 		{
-			p_rhs.m_data = NULL;
+			p_rhs.m_data = nullptr;
 			p_rhs.m_ownCoords = true;
 		}
 		/**
@@ -223,7 +223,7 @@ namespace Castor
 
 				m_data = p_rhs.m_data;
 				m_ownCoords = p_rhs.m_ownCoords;
-				p_rhs.m_data = NULL;
+				p_rhs.m_data = nullptr;
 				p_rhs.m_ownCoords = true;
 			}
 
@@ -242,7 +242,7 @@ namespace Castor
 			if ( m_ownCoords )
 			{
 				AlignedFree( m_data );
-				m_data = NULL;
+				m_data = nullptr;
 			}
 
 			m_data = p_data;

--- a/source/Core/CastorUtils/Src/ObjectPool.hpp
+++ b/source/Core/CastorUtils/Src/ObjectPool.hpp
@@ -110,11 +110,11 @@ namespace Castor
 		 *\~english
 		 *\brief		Allocates and builds an object from the pool's memory.
 		 *\param[in]	p_params	The object's constructor parameters.
-		 *\return		The built object, or NULL.
+		 *\return		The built object, or nullptr.
 		 *\~french
 		 *\brief		Alloue et construit un objet à partir de la mémoire du pool.
 		 *\param[in]	p_params	Les paramètres du constructeur de l'objet.
-		 *\return		L'objet construit, ou NULL.
+		 *\return		L'objet construit, ou nullptr.
 		 */
 		template< typename ... TParams >
 		Object * Allocate( TParams ... p_params )
@@ -123,7 +123,7 @@ namespace Castor
 
 			if ( !l_space )
 			{
-				return NULL;
+				return nullptr;
 			}
 
 			return new( l_space )Object( p_params... );
@@ -222,11 +222,11 @@ namespace Castor
 		 *\~english
 		 *\brief		Allocates and builds an object from the pool's memory.
 		 *\param[in]	p_params	The object's constructor parameters.
-		 *\return		The built object, or NULL.
+		 *\return		The built object, or nullptr.
 		 *\~french
 		 *\brief		Alloue et construit un objet à partir de la mémoire du pool.
 		 *\param[in]	p_params	Les paramètres du constructeur de l'objet.
-		 *\return		L'objet construit, ou NULL.
+		 *\return		L'objet construit, ou nullptr.
 		 */
 		template< typename ... TParams >
 		Object * Allocate( TParams ... p_params )
@@ -235,7 +235,7 @@ namespace Castor
 
 			if ( !l_space )
 			{
-				return NULL;
+				return nullptr;
 			}
 
 			return NewDeletePolicy< Object >::Ctor( l_space );

--- a/source/Core/CastorUtils/Src/Pixel.hpp
+++ b/source/Core/CastorUtils/Src/Pixel.hpp
@@ -379,7 +379,7 @@ namespace Castor
 		 */
 		inline component_const_ptr const_ptr()const
 		{
-			return ( m_pComponents ? & m_pComponents.get()[0] : NULL );
+			return ( m_pComponents ? & m_pComponents.get()[0] : nullptr );
 		}
 		/**
 		 *\~english
@@ -391,7 +391,7 @@ namespace Castor
 		 */
 		inline component_ptr ptr()
 		{
-			return ( m_pComponents ? & m_pComponents.get()[0] : NULL );
+			return ( m_pComponents ? & m_pComponents.get()[0] : nullptr );
 		}
 		/**
 		 *\~english
@@ -403,7 +403,7 @@ namespace Castor
 		 */
 		inline iterator begin()
 		{
-			return ( m_pComponents ? & m_pComponents.get()[0] : NULL );
+			return ( m_pComponents ? & m_pComponents.get()[0] : nullptr );
 		}
 		/**
 		 *\~english
@@ -415,7 +415,7 @@ namespace Castor
 		 */
 		inline const_iterator begin()const
 		{
-			return ( m_pComponents ? & m_pComponents.get()[0] : NULL );
+			return ( m_pComponents ? & m_pComponents.get()[0] : nullptr );
 		}
 		/**
 		 *\~english
@@ -427,7 +427,7 @@ namespace Castor
 		 */
 		inline iterator end()
 		{
-			return ( m_pComponents ? m_pComponents.get() + pixel_definitions< FT >::Size : NULL );
+			return ( m_pComponents ? m_pComponents.get() + pixel_definitions< FT >::Size : nullptr );
 		}
 		/**
 		 *\~english
@@ -439,7 +439,7 @@ namespace Castor
 		 */
 		inline const_iterator end()const
 		{
-			return ( m_pComponents ? m_pComponents.get() + pixel_definitions< FT >::Size : NULL );
+			return ( m_pComponents ? m_pComponents.get() + pixel_definitions< FT >::Size : nullptr );
 		}
 		/**
 		 *\~english

--- a/source/Core/CastorUtils/Src/PixelBuffer.hpp
+++ b/source/Core/CastorUtils/Src/PixelBuffer.hpp
@@ -54,7 +54,7 @@ namespace Castor
 		 *\param[in]	p_buffer		Buffer de données
 		 *\param[in]	p_bufferFormat	Format des pixels du buffer de données
 		 */
-		PxBuffer( Size const & p_size, uint8_t const * p_buffer = NULL, ePIXEL_FORMAT p_bufferFormat = ePIXEL_FORMAT_A8R8G8B8 );
+		PxBuffer( Size const & p_size, uint8_t const * p_buffer = nullptr, ePIXEL_FORMAT p_bufferFormat = ePIXEL_FORMAT_A8R8G8B8 );
 		/**
 		 *\~english
 		 *\brief		Copy Constructor

--- a/source/Core/CastorUtils/Src/PixelBufferBase.cpp
+++ b/source/Core/CastorUtils/Src/PixelBufferBase.cpp
@@ -40,7 +40,7 @@ namespace Castor
 		uint32_t l_size = count() * l_bpp;
 		m_buffer.resize( l_size );
 
-		if ( p_buffer == NULL )
+		if ( p_buffer == nullptr )
 		{
 			memset( m_buffer.data(), 0, l_size );
 		}
@@ -60,7 +60,7 @@ namespace Castor
 	void PxBufferBase::init( Size const & p_size )
 	{
 		m_size = p_size;
-		init( NULL, ePIXEL_FORMAT_A8R8G8B8 );
+		init( nullptr, ePIXEL_FORMAT_A8R8G8B8 );
 	}
 
 	void PxBufferBase::swap( PxBufferBase & p_pixelBuffer )

--- a/source/Core/CastorUtils/Src/PixelBufferBase.hpp
+++ b/source/Core/CastorUtils/Src/PixelBufferBase.hpp
@@ -309,7 +309,7 @@ namespace Castor
 		 *\param[in]	p_bufferFormat	Format des pixels du buffer de données
 		 *\return		Le buffer créé
 		 */
-		CU_API static PxBufferBaseSPtr create( Size const & p_size, ePIXEL_FORMAT p_wantedFormat, uint8_t const * p_buffer = NULL, ePIXEL_FORMAT p_bufferFormat = ePIXEL_FORMAT_A8R8G8B8 );
+		CU_API static PxBufferBaseSPtr create( Size const & p_size, ePIXEL_FORMAT p_wantedFormat, uint8_t const * p_buffer = nullptr, ePIXEL_FORMAT p_bufferFormat = ePIXEL_FORMAT_A8R8G8B8 );
 
 	private:
 		ePIXEL_FORMAT m_pixelFormat;

--- a/source/Core/CastorUtils/Src/SmartPtr.hpp
+++ b/source/Core/CastorUtils/Src/SmartPtr.hpp
@@ -28,10 +28,10 @@ namespace Castor
 	\date		08/12/2011
 	\~english
 	\brief		Dummy destructor
-	\remark		Used as a parameter to shared_ptr, to make deallocation dummy (only sets pointer to NULL)
+	\remark		Used as a parameter to shared_ptr, to make deallocation dummy (only sets pointer to nullptr)
 	\~french
 	\brief		Destructeur zombie
-	\remark		Utilisé en tant que paramètre à shared_ptr, afin d'avoir une désallocation zombie (ne fait que mettre le pointeur à NULL, sans le désallouer)
+	\remark		Utilisé en tant que paramètre à shared_ptr, afin d'avoir une désallocation zombie (ne fait que mettre le pointeur à nullptr, sans le désallouer)
 	*/
 	struct dummy_dtor
 	{

--- a/source/Core/CastorUtils/Src/StreamIndentBufferManager.hpp
+++ b/source/Core/CastorUtils/Src/StreamIndentBufferManager.hpp
@@ -128,7 +128,7 @@ namespace Castor
 
 				if ( cb_iter == m_list.end() )
 				{
-					return NULL;
+					return nullptr;
 				}
 
 				return cb_iter->second;

--- a/source/Core/CastorUtils/Src/StreamPrefixBufferManager.hpp
+++ b/source/Core/CastorUtils/Src/StreamPrefixBufferManager.hpp
@@ -120,7 +120,7 @@ namespace Castor
 
 				if ( cb_iter == m_list.end() )
 				{
-					return NULL;
+					return nullptr;
 				}
 
 				return cb_iter->second;

--- a/source/Core/CastorUtils/Src/StringUtils.inl
+++ b/source/Core/CastorUtils/Src/StringUtils.inl
@@ -20,8 +20,8 @@ namespace Castor
 						const facet_type & facet = std::use_facet< facet_type >( p_locale );
 						std::mbstate_t state = std::mbstate_t();
 						std::vector< wchar_t > dst( p_strIn.size() * facet.max_length(), 0 );
-						const char * endSrc = NULL;
-						wchar_t * endDst = NULL;
+						const char * endSrc = nullptr;
+						wchar_t * endDst = nullptr;
 						facet.in( state,
 								  p_strIn.data(), p_strIn.data() + p_strIn.size(), endSrc,
 								  &dst[0], &dst[0] + dst.size(), endDst
@@ -41,8 +41,8 @@ namespace Castor
 						const facet_type & facet = std::use_facet< facet_type >( p_locale );
 						std::mbstate_t state = std::mbstate_t();
 						std::vector< char > dst( p_strIn.size() * facet.max_length(), 0 );
-						const wchar_t * endSrc = NULL;
-						char * endDst = NULL;
+						const wchar_t * endSrc = nullptr;
+						char * endDst = nullptr;
 						facet.out( state,
 								   p_strIn.data(), p_strIn.data() + p_strIn.size(), endSrc,
 								   &dst[0], &dst[0] + dst.size(), endDst

--- a/source/Core/CastorUtils/Src/Unique.hpp
+++ b/source/Core/CastorUtils/Src/Unique.hpp
@@ -85,19 +85,19 @@ namespace Castor
 		 */
 		inline ~Unique()
 		{
-			DoGetInstance() = NULL;
+			DoGetInstance() = nullptr;
 		}
 
 	private:
 		/**
 		 *\~english
-		 *\return		The unique instance, NULL if none.
+		 *\return		The unique instance, nullptr if none.
 		 *\~french
-		 *\return		L'instance unique, NULL s'il n'y en a pas.
+		 *\return		L'instance unique, nullptr s'il n'y en a pas.
 		 */
 		static inline T *& DoGetInstance()
 		{
-			static T * l_pInstance = NULL;
+			static T * l_pInstance = nullptr;
 			return l_pInstance;
 		}
 	};

--- a/source/Core/CastorUtils/Src/UniqueObjectPool.hpp
+++ b/source/Core/CastorUtils/Src/UniqueObjectPool.hpp
@@ -77,14 +77,14 @@ namespace Castor
 			if ( DoGetInstance() )
 			{
 				delete DoGetInstance();
-				DoGetInstance() = NULL;
+				DoGetInstance() = nullptr;
 			}
 		}
 
 	private:
 		static inline MyObjectPool *& DoGetInstance()
 		{
-			static MyObjectPool * s_instance = NULL;
+			static MyObjectPool * s_instance = nullptr;
 			return s_instance;
 		}
 	};
@@ -143,14 +143,14 @@ namespace Castor
 			if ( DoGetInstance() )
 			{
 				delete DoGetInstance();
-				DoGetInstance() = NULL;
+				DoGetInstance() = nullptr;
 			}
 		}
 
 	private:
 		static inline MyAlignedObjectPool *& DoGetInstance()
 		{
-			static MyAlignedObjectPool * s_instance = NULL;
+			static MyAlignedObjectPool * s_instance = nullptr;
 			return s_instance;
 		}
 	};

--- a/source/Core/CastorUtils/Src/Utils.cpp
+++ b/source/Core/CastorUtils/Src/Utils.cpp
@@ -64,7 +64,7 @@ namespace Castor
 		bool GetScreenSize( uint32_t p_screen, Castor::Size & p_size )
 		{
 			stSCREEN l_screen = { p_screen, 0, p_size };
-			BOOL bRet = ::EnumDisplayMonitors( NULL, NULL, MonitorEnum, WPARAM( &l_screen ) );
+			BOOL bRet = ::EnumDisplayMonitors( nullptr, nullptr, MonitorEnum, WPARAM( &l_screen ) );
 			return true;
 		}
 
@@ -75,9 +75,9 @@ namespace Castor
 
 			if ( l_dwError != ERROR_SUCCESS )
 			{
-				LPTSTR l_szError = NULL;
+				LPTSTR l_szError = nullptr;
 
-				if ( ::FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, l_dwError, 0, LPTSTR( &l_szError ), 0, NULL ) != 0 )
+				if ( ::FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, nullptr, l_dwError, 0, LPTSTR( &l_szError ), 0, nullptr ) != 0 )
 				{
 					l_strReturn += cuT( " (" ) + String( l_szError ) + cuT( ")" );
 					string::replace( l_strReturn, cuT( "\r" ), cuT( "" ) );
@@ -119,9 +119,9 @@ namespace Castor
 		bool GetScreenSize( uint32_t p_screen, Castor::Size & p_size )
 		{
 			bool l_return = false;
-			Display * pdsp = NULL;
-			Screen * pscr = NULL;
-			pdsp = XOpenDisplay( NULL );
+			Display * pdsp = nullptr;
+			Screen * pscr = nullptr;
+			pdsp = XOpenDisplay( nullptr );
 
 			if ( !pdsp )
 			{
@@ -151,9 +151,9 @@ namespace Castor
 		{
 			String l_strReturn;
 			int l_error = errno;
-			char * l_szError = NULL;
+			char * l_szError = nullptr;
 
-			if ( l_error != 0 && ( l_szError = strerror( l_error ) ) != NULL )
+			if ( l_error != 0 && ( l_szError = strerror( l_error ) ) != nullptr )
 			{
 				l_strReturn = string::to_string( l_error ) + cuT( " (" ) + string::string_cast< xchar >( l_szError ) + cuT( ")" );
 				string::replace( l_strReturn, cuT( "\n" ), cuT( "" ) );

--- a/source/Core/CastorUtils/Src/ZipArchive.cpp
+++ b/source/Core/CastorUtils/Src/ZipArchive.cpp
@@ -34,7 +34,7 @@ namespace Castor
 				: public ZipArchive::ZipImpl
 		{
 			ZipImpl()
-				: m_zip( NULL )
+				: m_zip( nullptr )
 			{
 			}
 
@@ -85,7 +85,7 @@ namespace Castor
 					CASTOR_EXCEPTION( "Error while closing ZIP archive : " + l_error );
 				}
 
-				m_zip = NULL;
+				m_zip = nullptr;
 			}
 
 			virtual bool FindFolder( String const & p_folder )
@@ -324,7 +324,7 @@ namespace Castor
 
 	ZipArchive::Folder * ZipArchive::Folder::FindFolder( Path const & p_path )
 	{
-		ZipArchive::Folder * l_return = NULL;
+		ZipArchive::Folder * l_return = nullptr;
 
 		if ( name.empty() )
 		{

--- a/source/Plugins/Importers/AssimpImporter/Src/AssimpImporter.cpp
+++ b/source/Plugins/Importers/AssimpImporter/Src/AssimpImporter.cpp
@@ -168,7 +168,7 @@ namespace C3dAssimp
 	{
 		const aiNodeAnim * FindNodeAnim( const aiAnimation * p_animation, const String p_nodeName )
 		{
-			const aiNodeAnim * l_return = NULL;
+			const aiNodeAnim * l_return = nullptr;
 
 			for ( uint32_t i = 0; i < p_animation->mNumChannels && !l_return; ++i )
 			{

--- a/source/Plugins/Importers/FbxImporter/Src/FbxImporter.cpp
+++ b/source/Plugins/Importers/FbxImporter/Src/FbxImporter.cpp
@@ -395,8 +395,8 @@ namespace C3dFbx
 
 	SceneSPtr FbxSdkImporter::DoImportScene()
 	{
-		FbxManager * l_fbxManager = NULL;
-		FbxScene * l_fbxScene = NULL;
+		FbxManager * l_fbxManager = nullptr;
+		FbxScene * l_fbxScene = nullptr;
 
 		// Prepare the FBX SDK.
 		DoInitializeSdkObjects( l_fbxManager, l_fbxScene );
@@ -426,8 +426,8 @@ namespace C3dFbx
 
 		if ( !m_mesh->GetSubmeshCount() )
 		{
-			FbxManager * l_fbxManager = NULL;
-			FbxScene * l_fbxScene = NULL;
+			FbxManager * l_fbxManager = nullptr;
+			FbxScene * l_fbxScene = nullptr;
 
 			// Prepare the FBX SDK.
 			DoInitializeSdkObjects( l_fbxManager, l_fbxScene );
@@ -840,7 +840,7 @@ namespace C3dFbx
 	TextureUnitSPtr FbxSdkImporter::DoLoadTexture( FbxPropertyT< FbxDouble3 > const & p_property, Pass & p_pass, eTEXTURE_CHANNEL p_channel )
 	{
 		TextureUnitSPtr l_texture = nullptr;
-		FbxTexture * l_fbxtex = NULL;
+		FbxTexture * l_fbxtex = nullptr;
 		int l_index = 0;
 		FbxObject * l_object = p_property.GetSrcObject( l_index++ );
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GLSL/GlslExpr.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GLSL/GlslExpr.cpp
@@ -8,24 +8,24 @@ namespace GlRender
 	namespace GLSL
 	{
 		Expr::Expr()
-			: m_writer( NULL )
+			: m_writer( nullptr )
 		{
 		}
 
 		Expr::Expr( int p_value )
-			: m_writer( NULL )
+			: m_writer( nullptr )
 		{
 			m_value << p_value;
 		}
 
 		Expr::Expr( float p_value )
-			: m_writer( NULL )
+			: m_writer( nullptr )
 		{
 			m_value << p_value;
 		}
 
 		Expr::Expr( double p_value )
-			: m_writer( NULL )
+			: m_writer( nullptr )
 		{
 			m_value << p_value;
 		}

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GLSL/GlslWriter.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GLSL/GlslWriter.cpp
@@ -38,7 +38,7 @@ namespace GlRender
 		Ubo::Ubo( GlslWriter & p_writer, Castor::String const & p_name )
 			: m_writer( p_writer )
 			, m_name( p_name )
-			, m_block( NULL )
+			, m_block( nullptr )
 		{
 			if ( m_writer.GetOpenGl().HasUbo() )
 			{
@@ -52,7 +52,7 @@ namespace GlRender
 		void Ubo::End()
 		{
 			delete m_block;
-			m_block = NULL;
+			m_block = nullptr;
 			m_writer.m_uniform = cuT( "uniform " );
 
 			if ( m_writer.GetOpenGl().HasUbo() )
@@ -68,7 +68,7 @@ namespace GlRender
 		Struct::Struct( GlslWriter & p_writer, Castor::String const & p_name )
 			: m_writer( p_writer )
 			, m_name( p_name )
-			, m_block( NULL )
+			, m_block( nullptr )
 		{
 			m_writer << Endl();
 			m_writer << cuT( "struct " ) << p_name << Endl();
@@ -78,7 +78,7 @@ namespace GlRender
 		void Struct::End()
 		{
 			delete m_block;
-			m_block = NULL;
+			m_block = nullptr;
 			m_writer << cuT( ";" ) << Endl();
 		}
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlBufferBase.inl
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlBufferBase.inl
@@ -50,7 +50,7 @@ namespace GlRender
 	template< typename T >
 	T * GlBufferBase< T >::Lock( uint32_t p_offset, uint32_t p_count, uint32_t p_flags )
 	{
-		T * l_return = NULL;
+		T * l_return = nullptr;
 
 		if ( this->GetGlName() != eGL_INVALID_INDEX )
 		{
@@ -63,7 +63,7 @@ namespace GlRender
 	template< typename T >
 	T * GlBufferBase< T >::Lock( eGL_LOCK p_access )
 	{
-		T * l_return = NULL;
+		T * l_return = nullptr;
 
 		if ( this->GetGlName() != eGL_INVALID_INDEX )
 		{

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlDirectTextureStorage.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlDirectTextureStorage.cpp
@@ -76,7 +76,7 @@ namespace GlRender
 	uint8_t * GlDirectTextureStorage::DoLock( uint32_t p_lock )
 	{
 		REQUIRE( !m_buffer.expired() );
-		uint8_t * l_return = NULL;
+		uint8_t * l_return = nullptr;
 
 		if ( ( m_cpuAccess && p_lock & eACCESS_TYPE_READ ) == eACCESS_TYPE_READ
 				|| ( m_cpuAccess & p_lock & eACCESS_TYPE_WRITE ) == eACCESS_TYPE_WRITE )

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlFrameVariableBuffer.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlFrameVariableBuffer.cpp
@@ -887,7 +887,7 @@ namespace GlRender
 				{
 					GetOpenGl().GetActiveUniformBlockiv( l_program->GetGlName(), m_uniformBlockIndex, eGL_UNIFORM_BLOCK_DATA_SIZE, &m_uniformBlockSize );
 					m_glBuffer.Create();
-					m_glBuffer.Fill( NULL, m_uniformBlockSize, eBUFFER_ACCESS_TYPE_DYNAMIC, eBUFFER_ACCESS_NATURE_DRAW );
+					m_glBuffer.Fill( nullptr, m_uniformBlockSize, eBUFFER_ACCESS_TYPE_DYNAMIC, eBUFFER_ACCESS_NATURE_DRAW );
 					m_glBuffer.Bind();
 					GetOpenGl().BindBufferBase( eGL_BUFFER_TARGET_UNIFORM, m_index, m_glBuffer.GetGlName() );
 					GetOpenGl().UniformBlockBinding( l_program->GetGlName(), m_uniformBlockIndex, m_index );

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlIndexBufferObject.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlIndexBufferObject.cpp
@@ -66,7 +66,7 @@ namespace GlRender
 
 	uint32_t * GlIndexBufferObject::Lock( uint32_t p_offset, uint32_t p_count, uint32_t p_flags )
 	{
-		uint32_t * l_return = NULL;
+		uint32_t * l_return = nullptr;
 		HardwareBufferPtr l_pBuffer = GetCpuBuffer();
 
 		if ( l_pBuffer && l_pBuffer->IsAssigned() )

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlMatrixFrameVariable.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlMatrixFrameVariable.hpp
@@ -30,7 +30,7 @@ namespace GlRender
 		, public GlFrameVariableBase
 	{
 	public:
-		GlMatrixFrameVariable( OpenGl & p_gl, uint32_t p_occurences, GlShaderProgram * p_program = NULL );
+		GlMatrixFrameVariable( OpenGl & p_gl, uint32_t p_occurences, GlShaderProgram * p_program = nullptr );
 		GlMatrixFrameVariable( OpenGl & p_gl, Castor3D::MatrixFrameVariable<T, Rows, Columns> * p_variable );
 		virtual ~GlMatrixFrameVariable();
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlMswContext.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlMswContext.hpp
@@ -52,10 +52,11 @@ namespace GlRender
 		}
 
 	protected:
-		bool DoCreateGl3Context( Castor3D::RenderWindow * p_window );
-		HGLRC DoCreateDummyContext( Castor3D::RenderWindow * p_window );
-		bool DoSelectPixelFormat( Castor3D::RenderWindow * p_window );
-		bool DoSelectStereoPixelFormat( Castor3D::RenderWindow * p_window );
+		void DoInitialiseOpenGL( Castor::ePIXEL_FORMAT p_colour, Castor::ePIXEL_FORMAT p_depth, bool p_stereo );
+		HGLRC DoCreateDummyContext( Castor::ePIXEL_FORMAT p_colour, Castor::ePIXEL_FORMAT p_depth, bool p_stereo );
+		bool DoSelectPixelFormat( Castor::ePIXEL_FORMAT p_colour, Castor::ePIXEL_FORMAT p_depth, bool p_stereo );
+		bool DoSelectStereoPixelFormat( Castor::ePIXEL_FORMAT p_colour, Castor::ePIXEL_FORMAT p_depth );
+		bool DoCreateGl3Context();
 
 	protected:
 		HDC m_hDC;

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlOneFrameVariable.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlOneFrameVariable.hpp
@@ -30,7 +30,7 @@ namespace GlRender
 		, public GlFrameVariableBase
 	{
 	public:
-		GlOneFrameVariable( OpenGl & p_gl, uint32_t p_occurences, GlShaderProgram * p_program = NULL );
+		GlOneFrameVariable( OpenGl & p_gl, uint32_t p_occurences, GlShaderProgram * p_program = nullptr );
 		GlOneFrameVariable( OpenGl & p_gl, Castor3D::OneFrameVariable< T > * p_variable );
 		virtual ~GlOneFrameVariable();
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlPointFrameVariable.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlPointFrameVariable.hpp
@@ -30,7 +30,7 @@ namespace GlRender
 		, public GlFrameVariableBase
 	{
 	public:
-		GlPointFrameVariable( OpenGl & p_gl, uint32_t p_occurences, GlShaderProgram * p_program = NULL );
+		GlPointFrameVariable( OpenGl & p_gl, uint32_t p_occurences, GlShaderProgram * p_program = nullptr );
 		GlPointFrameVariable( OpenGl & p_gl, Castor3D::PointFrameVariable<T, Count> * p_variable );
 		virtual ~GlPointFrameVariable();
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlRenderSystemPrerequisites.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlRenderSystemPrerequisites.hpp
@@ -39,7 +39,7 @@ http://www.gnu.org/copyleft/lesser.txt.
 #	define C3D_Gl_API
 #endif
 
-#define BUFFER_OFFSET( n ) ( ( uint8_t * )NULL + ( n ) )
+#define BUFFER_OFFSET( n ) ( ( uint8_t * )nullptr + ( n ) )
 
 using Castor::real;
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlShaderObject.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlShaderObject.cpp
@@ -19,7 +19,7 @@ namespace GlRender
 				  std::bind( &OpenGl::DeleteShader, std::ref( p_gl ), std::placeholders::_1 ),
 				  std::bind( &OpenGl::IsShader, std::ref( p_gl ), std::placeholders::_1 )
 				)
-		, m_shaderProgram( NULL )
+		, m_shaderProgram( nullptr )
 	{
 	}
 
@@ -142,7 +142,7 @@ namespace GlRender
 		if ( m_status == eSHADER_STATUS_COMPILED && m_shaderProgram && m_parent->GetRenderSystem()->HasShaderType( m_type ) )
 		{
 			GetOpenGl().DetachShader( m_shaderProgram->GetGlName(), GetGlName() );
-			m_shaderProgram = NULL;
+			m_shaderProgram = nullptr;
 		}
 	}
 

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlShaderObject.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlShaderObject.hpp
@@ -77,11 +77,11 @@ namespace GlRender
 		 *\~english
 		 *\brief		Gives the wanted parameter from compiled shader
 		 *\param[in]	p_name	The parameter name
-		 *\return		\p NULL if not found or if shader isn't compiled
+		 *\return		\p nullptr if not found or if shader isn't compiled
 		 *\~french
 		 *\brief		Récupère le paramètre à partir du shader compilé
 		 *\param[in]	p_name	Le nom du paramètre
-		 *\return		\p NULL si le paramètre n'a pas été trouvé ou si le shader n'est pas compilé
+		 *\return		\p nullptr si le paramètre n'a pas été trouvé ou si le shader n'est pas compilé
 		 */
 		uint32_t GetParameter( Castor::String const & p_name );
 		/**

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlUploadPixelBuffer.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlUploadPixelBuffer.cpp
@@ -22,6 +22,6 @@ namespace GlRender
 
 	bool GlUploadPixelBuffer::Initialise()
 	{
-		return Fill( NULL, m_pixelsSize );
+		return Fill( nullptr, m_pixelsSize );
 	}
 }

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlVertexBufferObject.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlVertexBufferObject.cpp
@@ -63,7 +63,7 @@ namespace GlRender
 
 	uint8_t * GlVertexBufferObject::Lock( uint32_t p_offset, uint32_t p_count, uint32_t p_flags )
 	{
-		uint8_t * l_return = NULL;
+		uint8_t * l_return = nullptr;
 		HardwareBufferPtr l_pBuffer = GetCpuBuffer();
 
 		if ( l_pBuffer && l_pBuffer->IsAssigned() )

--- a/source/Plugins/Renderers/GlRenderSystem/Src/GlX11Context.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/GlX11Context.cpp
@@ -28,16 +28,16 @@ typedef XVisualInfo * ( FnGlXGetVisualFromFBConfigProc	)( Display *, GLXFBConfig
 typedef FnGlXChooseFBConfigProc * PFnGlXChooseFBConfigProc;
 typedef FnGlXGetVisualFromFBConfigProc * PFnGlXGetVisualFromFBConfigProc;
 
-PFnGlXChooseFBConfigProc g_pfnGlXChooseFBConfig = NULL;
-PFnGlXGetVisualFromFBConfigProc g_pfnGlXGetVisualFromFBConfig = NULL;
+PFnGlXChooseFBConfigProc g_pfnGlXChooseFBConfig = nullptr;
+PFnGlXGetVisualFromFBConfigProc g_pfnGlXGetVisualFromFBConfig = nullptr;
 
 GlContextImpl::GlContextImpl( OpenGl & p_gl, GlContext * p_context )
 	: Holder( p_gl )
-	, m_display( NULL )
+	, m_display( nullptr )
 	, m_glxVersion( 10 )
-	, m_glxContext( NULL )
+	, m_glxContext( nullptr )
 	, m_drawable( None )
-	, m_fbConfig( NULL )
+	, m_fbConfig( nullptr )
 	, m_context( p_context )
 	, m_initialised( false )
 {
@@ -64,9 +64,9 @@ bool GlContextImpl::Initialise( RenderWindow * p_window )
 	}
 
 	GlRenderSystem * l_renderSystem = static_cast< GlRenderSystem * >( p_window->GetEngine()->GetRenderSystem() );
-	GlContextSPtr l_pMainContext = std::static_pointer_cast< GlContext >( l_renderSystem->GetMainContext() );
+	GlContextSPtr l_mainContext = std::static_pointer_cast< GlContext >( l_renderSystem->GetMainContext() );
 
-	if ( l_pMainContext )
+	if ( l_mainContext )
 	{
 		Logger::LogInfo( cuT( "***********************************************************************************************************************" ) );
 		Logger::LogInfo( cuT( "Initialising OpenGL" ) );
@@ -77,7 +77,7 @@ bool GlContextImpl::Initialise( RenderWindow * p_window )
 		int l_screen = DefaultScreen( m_display );
 		int l_major, l_minor;
 		bool l_ok = glXQueryVersion( m_display, &l_major, &l_minor );
-		XVisualInfo * l_visualInfo = NULL;
+		XVisualInfo * l_visualInfo = nullptr;
 
 		if ( l_ok )
 		{
@@ -146,13 +146,13 @@ bool GlContextImpl::Initialise( RenderWindow * p_window )
 
 		if ( l_visualInfo )
 		{
-			if ( l_pMainContext )
+			if ( l_mainContext )
 			{
-				m_glxContext = glXCreateContext( m_display, l_visualInfo, l_pMainContext->GetImpl()->GetContext(), GL_TRUE );
+				m_glxContext = glXCreateContext( m_display, l_visualInfo, l_mainContext->GetImpl()->GetContext(), GL_TRUE );
 			}
 			else
 			{
-				m_glxContext = glXCreateContext( m_display, l_visualInfo, NULL, GL_TRUE );
+				m_glxContext = glXCreateContext( m_display, l_visualInfo, nullptr, GL_TRUE );
 			}
 
 			if ( !m_glxContext )
@@ -167,7 +167,7 @@ bool GlContextImpl::Initialise( RenderWindow * p_window )
 				{
 					glXMakeCurrent( m_display, m_drawable, m_glxContext );
 					GetOpenGl().PreInitialise( String() );
-					glXMakeCurrent( m_display, None, NULL );
+					glXMakeCurrent( m_display, None, nullptr );
 				}
 
 				if ( GetOpenGl().GetVersion() >= 30 )
@@ -184,7 +184,7 @@ bool GlContextImpl::Initialise( RenderWindow * p_window )
 					glXMakeCurrent( m_display, m_drawable, m_glxContext );
 					l_renderSystem->Initialise();
 					p_window->GetEngine()->GetMaterialManager().Initialise();
-					glXMakeCurrent( m_display, None, NULL );
+					glXMakeCurrent( m_display, None, nullptr );
 				}
 			}
 
@@ -213,7 +213,7 @@ bool GlContextImpl::Initialise( RenderWindow * p_window )
 #endif
 		UpdateVSync( p_window->GetVSync() );
 
-		if ( l_pMainContext )
+		if ( l_mainContext )
 		{
 			Logger::LogInfo( cuT( "OpenGL Initialisation Ended" ) );
 			Logger::LogInfo( cuT( "***********************************************************************************************************************" ) );
@@ -269,7 +269,7 @@ void GlContextImpl::UpdateVSync( bool p_enable )
 XVisualInfo * GlContextImpl::DoCreateVisualInfoWithFBConfig( RenderWindow * p_window, IntArray & p_arrayAttribs, int p_screen )
 {
 	Logger::LogDebug( cuT( "GlXContext::Create - Using FBConfig" ) );
-	XVisualInfo * l_return = NULL;
+	XVisualInfo * l_return = nullptr;
 	int l_result = 0;
 	m_fbConfig = g_pfnGlXChooseFBConfig( m_display, p_screen, &p_arrayAttribs[0], &l_result );
 
@@ -386,7 +386,7 @@ bool GlContextImpl::DoCreateGl3Context( Castor3D::RenderWindow * p_window )
 {
 	bool l_return = false;
 	GlRenderSystem * l_renderSystem = static_cast< GlRenderSystem * >( p_window->GetEngine()->GetRenderSystem() );
-	GlContextSPtr l_pMainContext = std::static_pointer_cast< GlContext >( l_renderSystem->GetMainContext() );
+	GlContextSPtr l_mainContext = std::static_pointer_cast< GlContext >( l_renderSystem->GetMainContext() );
 
 	if ( GetOpenGl().HasCreateContextAttribs() )
 	{
@@ -401,19 +401,19 @@ bool GlContextImpl::DoCreateGl3Context( Castor3D::RenderWindow * p_window )
 		l_arrayAttribs.push_back( GLX_CONTEXT_FLAGS_ARB	);
 		l_arrayAttribs.push_back( GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB	);
 		l_arrayAttribs.push_back( None	);
-		glXMakeCurrent( m_display, None, NULL );
+		glXMakeCurrent( m_display, None, nullptr );
 		GetOpenGl().DeleteContext( m_display, m_glxContext );
 
-		if ( l_pMainContext )
+		if ( l_mainContext )
 		{
-			m_glxContext = GetOpenGl().CreateContextAttribs( m_display, m_fbConfig[0], l_pMainContext->GetImpl()->GetContext(), true, &l_arrayAttribs[0] );
+			m_glxContext = GetOpenGl().CreateContextAttribs( m_display, m_fbConfig[0], l_mainContext->GetImpl()->GetContext(), true, &l_arrayAttribs[0] );
 		}
 		else
 		{
-			m_glxContext = GetOpenGl().CreateContextAttribs( m_display, m_fbConfig[0], NULL, true, &l_arrayAttribs[0] );
+			m_glxContext = GetOpenGl().CreateContextAttribs( m_display, m_fbConfig[0], nullptr, true, &l_arrayAttribs[0] );
 		}
 
-		l_return = m_glxContext != NULL;
+		l_return = m_glxContext != nullptr;
 
 		if ( l_return )
 		{

--- a/source/Plugins/Renderers/GlRenderSystem/Src/OpenGl.cpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/OpenGl.cpp
@@ -519,7 +519,7 @@ void * BufFunctions::MapBuffer( eGL_BUFFER_TARGET p_target, eGL_LOCK access )
 
 	if ( !glCheckError( GetOpenGl(), cuT( "glMapBuffer" ) ) )
 	{
-		l_return = NULL;
+		l_return = nullptr;
 	}
 
 	return l_return;
@@ -533,14 +533,14 @@ bool BufFunctions::UnmapBuffer( eGL_BUFFER_TARGET p_target )
 
 void * BufFunctions::MapBufferRange( eGL_BUFFER_TARGET p_target, ptrdiff_t offset, ptrdiff_t length, uint32_t access )
 {
-	void * l_return = NULL;
+	void * l_return = nullptr;
 //	if( length + offset < GL_BUFFER_SIZE )
 	{
 		l_return = m_pfnMapBufferRange( p_target, offset, length, access );
 
 		if ( !glCheckError( GetOpenGl(), cuT( "glMapBufferRange" ) ) )
 		{
-			l_return = NULL;
+			l_return = nullptr;
 		}
 	}
 	return l_return;
@@ -591,7 +591,7 @@ void * BufFunctionsDSA::MapBuffer( eGL_BUFFER_TARGET p_target, eGL_LOCK access )
 
 	if ( !glCheckError( GetOpenGl(), cuT( "glMapBuffer" ) ) )
 	{
-		l_return = NULL;
+		l_return = nullptr;
 	}
 
 	return l_return;
@@ -605,14 +605,14 @@ bool BufFunctionsDSA::UnmapBuffer( eGL_BUFFER_TARGET p_target )
 
 void * BufFunctionsDSA::MapBufferRange( eGL_BUFFER_TARGET p_target, ptrdiff_t offset, ptrdiff_t length, uint32_t access )
 {
-	void * l_return = NULL;
+	void * l_return = nullptr;
 //	if( length + offset < GL_BUFFER_SIZE )
 	{
 		l_return = m_pfnMapNamedBufferRange( m_uiBuffer, offset, length, access );
 
 		if ( !glCheckError( GetOpenGl(), cuT( "glMapBufferRange" ) ) )
 		{
-			l_return = NULL;
+			l_return = nullptr;
 		}
 	}
 	return l_return;
@@ -632,8 +632,8 @@ OpenGl::OpenGl( GlRenderSystem & p_renderSystem )
 	: m_bHasAnisotropic( false )
 	, m_bHasInstancedDraw( false )
 	, m_bHasInstancedArrays( false )
-	, m_pTexFunctions( NULL )
-	, m_pBufFunctions( NULL )
+	, m_pTexFunctions( nullptr )
+	, m_pBufFunctions( nullptr )
 	, m_pfnReadPixels()
 	, m_pfnBlitFramebuffer()
 	, m_pfnTexImage2DMultisample()
@@ -1487,9 +1487,9 @@ bool OpenGl::Initialise()
 void OpenGl::Cleanup()
 {
 	delete m_pTexFunctions;
-	m_pTexFunctions = NULL;
+	m_pTexFunctions = nullptr;
 	delete m_pBufFunctions;
-	m_pBufFunctions = NULL;
+	m_pBufFunctions = nullptr;
 	m_bHasVao = false;
 	m_bHasUbo = false;
 	m_bHasPbo = false;
@@ -1638,7 +1638,7 @@ HGLRC OpenGl::CreateContext( HDC hdc )const
 
 bool OpenGl::HasCreateContextAttribs()const
 {
-	return m_pfnCreateContextAttribs != NULL;
+	return m_pfnCreateContextAttribs != nullptr;
 }
 
 HGLRC OpenGl::CreateContextAttribs( HDC hDC, HGLRC hShareContext, int const * attribList )const
@@ -1685,7 +1685,7 @@ GLXContext OpenGl::CreateContext( Display * pDisplay, XVisualInfo * pVisualInfo,
 
 bool OpenGl::HasCreateContextAttribs()const
 {
-	return m_pfnCreateContextAttribs != NULL;
+	return m_pfnCreateContextAttribs != nullptr;
 }
 
 GLXContext OpenGl::CreateContextAttribs( Display * pDisplay, GLXFBConfig fbconfig, GLXContext shareList, Bool direct, int const * attribList )const
@@ -2355,12 +2355,12 @@ bool OpenGl::BinormalPointer( uint32_t type, uint32_t stride, void const * point
 
 bool OpenGl::HasTangentPointer()const
 {
-	return m_pfnTangentPointer != NULL;
+	return m_pfnTangentPointer != nullptr;
 }
 
 bool OpenGl::HasBinormalPointer()const
 {
-	return m_pfnBinormalPointer != NULL;
+	return m_pfnBinormalPointer != nullptr;
 }
 
 bool OpenGl::ColorPointer( int size, uint32_t type, uint32_t stride, void const * pointer )const

--- a/source/Plugins/Renderers/GlRenderSystem/Src/OpenGl.hpp
+++ b/source/Plugins/Renderers/GlRenderSystem/Src/OpenGl.hpp
@@ -1474,21 +1474,21 @@ namespace GlRender
 #else
 			p_func = reinterpret_cast< Func >( glXGetProcAddressARB( ( GLubyte const * )Castor::string::string_cast< char >( p_name ).c_str() ) );
 #endif
-			return p_func != NULL;
+			return p_func != nullptr;
 		}
 
 		template< typename Ret, typename ... Arguments >
 		bool GetFunction( Castor::String const & p_name, std::function< Ret( Arguments... ) > & p_func )
 		{
 			typedef Ret( CALLBACK * PFNType )( Arguments... );
-			PFNType l_pfnResult = NULL;
+			PFNType l_pfnResult = nullptr;
 
 			if ( GetFunction( p_name, l_pfnResult ) )
 			{
 				p_func = l_pfnResult;
 			}
 
-			return l_pfnResult != NULL;
+			return l_pfnResult != nullptr;
 		}
 	}
 

--- a/source/Samples/CastorViewer/Src/CastorViewer.cpp
+++ b/source/Samples/CastorViewer/Src/CastorViewer.cpp
@@ -34,7 +34,7 @@ namespace CastorViewer
 {
 	CastorViewerApp::CastorViewerApp()
 		: CastorApplication( cuT( "CastorViewer" ), cuT( "Castor Viewer" ), 7 )
-		, m_mainFrame( NULL )
+		, m_mainFrame( nullptr )
 	{
 	}
 
@@ -76,7 +76,7 @@ namespace CastorViewer
 		else
 		{
 			delete m_mainFrame;
-			m_mainFrame = NULL;
+			m_mainFrame = nullptr;
 		}
 
 		return m_mainFrame;

--- a/source/Samples/CastorViewer/Src/MainFrame.hpp
+++ b/source/Samples/CastorViewer/Src/MainFrame.hpp
@@ -50,6 +50,7 @@ namespace CastorViewer
 		void DoCleanupScene();
 		void DoSaveFrame();
 		bool DoStartRecord();
+		void DoRecordFrame();
 		void DoStopRecord();
 
 	private:

--- a/source/Samples/CastorViewer/Src/RenderPanel.cpp
+++ b/source/Samples/CastorViewer/Src/RenderPanel.cpp
@@ -116,7 +116,7 @@ namespace CastorViewer
 		for ( int i = 0; i < eTIMER_ID_COUNT; i++ )
 		{
 			delete m_pTimer[i];
-			m_pTimer[i] = NULL;
+			m_pTimer[i] = nullptr;
 		}
 	}
 

--- a/source/Samples/GuiCommon/Src/AdditionalProperties.hpp
+++ b/source/Samples/GuiCommon/Src/AdditionalProperties.hpp
@@ -59,7 +59,7 @@ http://www.gnu.org/copyleft/lesser.txt.
 	}
 
 #define GC_IMPLEMENT_CLASS_COMMON1( name, basename, func )\
-    GC_IMPLEMENT_CLASS_COMMON( name, basename, NULL, func )
+    GC_IMPLEMENT_CLASS_COMMON( name, basename, nullptr, func )
 
 // Single inheritance with one base class
 #define GC_IMPLEMENT_DYNAMIC_CLASS( name, basename )\

--- a/source/Samples/GuiCommon/Src/CastorApplication.cpp
+++ b/source/Samples/GuiCommon/Src/CastorApplication.cpp
@@ -81,10 +81,10 @@ namespace GuiCommon
 	CastorApplication::CastorApplication( String const & p_internalName, String const & p_displayName, uint32_t p_steps )
 		: m_internalName( p_internalName )
 		, m_displayName( p_displayName )
-		, m_castor( NULL )
+		, m_castor( nullptr )
 		, m_rendererType( eRENDERER_TYPE_UNDEFINED )
 		, m_steps( p_steps + 4 )
-		, m_splashScreen( NULL )
+		, m_splashScreen( nullptr )
 	{
 #if defined( __WXGTK__ )
 		XInitThreads();
@@ -105,7 +105,7 @@ namespace GuiCommon
 		SplashScreen l_splashScreen( m_displayName, wxPoint( 10, 230 ), wxPoint( 200, 300 ), wxPoint( 180, 260 ), wxPoint( ( l_rect.width - 512 ) / 2, ( l_rect.height - 384 ) / 2 ), m_steps );
 		m_splashScreen = &l_splashScreen;
 		wxApp::SetTopWindow( m_splashScreen );
-		wxWindow * l_window = NULL;
+		wxWindow * l_window = nullptr;
 
 		if ( l_return )
 		{
@@ -122,7 +122,7 @@ namespace GuiCommon
 				if ( l_return )
 				{
 					l_window = DoInitialiseMainFrame( &l_splashScreen );
-					l_return = l_window != NULL;
+					l_return = l_window != nullptr;
 				}
 			}
 			catch ( Exception & exc )
@@ -139,7 +139,7 @@ namespace GuiCommon
 
 		wxApp::SetTopWindow( l_window );
 		l_splashScreen.Close();
-		m_splashScreen = NULL;
+		m_splashScreen = nullptr;
 
 		return l_return;
 	}
@@ -160,7 +160,7 @@ namespace GuiCommon
 		wxCmdLineParser l_parser( wxApp::argc, wxApp::argv );
 		l_parser.AddSwitch( wxT( "h" ), wxT( "help" ), _( "Displays this help" ) );
 		l_parser.AddOption( wxT( "l" ), wxT( "log" ), _( "Defines log level" ), wxCMD_LINE_VAL_NUMBER );
-		l_parser.AddOption( wxT( "f" ), wxT( "file" ), _( "Defines initial scene file" ), wxCMD_LINE_VAL_STRING );
+		l_parser.AddParam( _( "Defines initial scene file" ), wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL );
 		l_parser.AddSwitch( wxT( "opengl" ), wxEmptyString, _( "Defines the renderer to OpenGl" ) );
 		l_parser.AddSwitch( wxT( "directx" ), wxEmptyString, _( "Defines the renderer to Direct3D (11)" ) );
 		bool l_return = l_parser.Parse( false ) == 0;
@@ -190,9 +190,9 @@ namespace GuiCommon
 
 			wxString l_strFileName;
 
-			if ( l_parser.Found( wxT( 'f' ), &l_strFileName ) )
+			if ( l_parser.GetParamCount() > 0 )
 			{
-				m_fileName = make_String( l_strFileName );
+				m_fileName = make_String( l_parser.GetParam( 0 ) );
 			}
 		}
 
@@ -272,7 +272,7 @@ namespace GuiCommon
 
 		if ( m_rendererType == eRENDERER_TYPE_UNDEFINED )
 		{
-			RendererSelector m_dialog( m_castor, NULL, m_displayName );
+			RendererSelector m_dialog( m_castor, nullptr, m_displayName );
 			int l_iReturn = m_dialog.ShowModal();
 
 			if ( l_iReturn == wxID_OK )
@@ -300,7 +300,7 @@ namespace GuiCommon
 	void CastorApplication::DoCleanupCastor()
 	{
 		delete m_castor;
-		m_castor = NULL;
+		m_castor = nullptr;
 	}
 
 	void CastorApplication::DoLoadPlugins( SplashScreen & p_splashScreen )

--- a/source/Samples/GuiCommon/Src/CastorApplication.hpp
+++ b/source/Samples/GuiCommon/Src/CastorApplication.hpp
@@ -164,11 +164,11 @@ namespace GuiCommon
 		 *\~english
 		 *\brief		Should contain the application main frame initialisation code.
 		 *\param[in]	p_splashScreen	The splash screen.
-		 *\return		The main frame. If NULL, the application will stop.
+		 *\return		The main frame. If nullptr, the application will stop.
 		 *\~french
 		 *\brief		Devrait contenir le code d'initialisation de la fenêtre principale de l'application.
 		 *\param[in]	p_splashScreen	Le splash screen.
-		 *\return		La fenêtre principale. Si NULL, l'application s'arrêtera.
+		 *\return		La fenêtre principale. Si nullptr, l'application s'arrêtera.
 		 */
 		virtual wxWindow * DoInitialiseMainFrame( SplashScreen * p_splashScreen ) = 0;
 

--- a/source/Samples/GuiCommon/Src/FrameVariableTreeItemProperty.cpp
+++ b/source/Samples/GuiCommon/Src/FrameVariableTreeItemProperty.cpp
@@ -62,7 +62,7 @@ namespace GuiCommon
 
 		wxPGProperty * DoBuildValueProperty( wxString const & p_name, FrameVariableSPtr p_variable )
 		{
-			wxPGProperty * l_return = NULL;
+			wxPGProperty * l_return = nullptr;
 
 			switch ( p_variable->GetFullType() )
 			{

--- a/source/Samples/GuiCommon/Src/GuiCommonPrerequisites.cpp
+++ b/source/Samples/GuiCommon/Src/GuiCommonPrerequisites.cpp
@@ -573,7 +573,7 @@ namespace GuiCommon
 #elif defined( __linux__ )
 		GtkWidget * l_pGtkWidget = static_cast< GtkWidget * >( p_window->GetHandle() );
 		GLXDrawable l_drawable = None;
-		Display * l_pDisplay = NULL;
+		Display * l_pDisplay = nullptr;
 
 		if ( l_pGtkWidget && l_pGtkWidget->window )
 		{

--- a/source/Samples/GuiCommon/Src/ImagesLoader.cpp
+++ b/source/Samples/GuiCommon/Src/ImagesLoader.cpp
@@ -33,7 +33,7 @@ namespace GuiCommon
 
 	wxImage * ImagesLoader::GetBitmap( uint32_t p_id )
 	{
-		wxImage * l_return = NULL;
+		wxImage * l_return = nullptr;
 		m_mutex.lock();
 		ImageIdMapIt l_it = m_mapImages.find( p_id );
 		ImageIdMapConstIt l_itEnd = m_mapImages.end();

--- a/source/Samples/GuiCommon/Src/MaterialsList.cpp
+++ b/source/Samples/GuiCommon/Src/MaterialsList.cpp
@@ -37,7 +37,7 @@ namespace GuiCommon
 {
 	MaterialsList::MaterialsList( PropertiesHolder * p_propertiesHolder, wxWindow * p_parent, wxPoint const & p_ptPos, wxSize const & p_size )
 		: wxTreeCtrl( p_parent, wxID_ANY, p_ptPos, p_size, wxTR_DEFAULT_STYLE | wxTR_HIDE_ROOT | wxNO_BORDER )
-		, m_engine( NULL )
+		, m_engine( nullptr )
 		, m_propertiesHolder( p_propertiesHolder )
 	{
 		wxBusyCursor l_wait;
@@ -211,13 +211,13 @@ namespace GuiCommon
 	//
 	//wxImage * MaterialsList::CreatePassImage( PassSPtr p_pPass, uint32_t p_width, uint32_t p_height )
 	//{
-	//	wxImage * l_return = NULL;
+	//	wxImage * l_return = nullptr;
 	//
 	//	if ( p_pPass )
 	//	{
 	//		wxBitmap l_bmpReturn( p_width, p_height, 32 );
 	//		wxMemoryDC l_dcReturn( l_bmpReturn );
-	//		wxImage * l_pMask = NULL;
+	//		wxImage * l_pMask = nullptr;
 	//		typedef uint32_t uint;
 	//		l_pMask = new wxImage( p_width, p_height );
 	//		l_pMask->InitAlpha();
@@ -312,7 +312,7 @@ namespace GuiCommon
 	//
 	//wxImage * MaterialsList::CreateTextureUnitImage( TextureUnitSPtr p_pUnit, uint32_t p_width, uint32_t p_height )
 	//{
-	//	wxImage * l_return = NULL;
+	//	wxImage * l_return = nullptr;
 	//
 	//	if ( p_pUnit )
 	//	{

--- a/source/Samples/GuiCommon/Src/PassTreeItemProperty.cpp
+++ b/source/Samples/GuiCommon/Src/PassTreeItemProperty.cpp
@@ -186,7 +186,7 @@ namespace GuiCommon
 	bool PassTreeItemProperty::OnEditShader( wxPGProperty * p_property )
 	{
 		PassSPtr l_pass = GetPass();
-		ShaderDialog * l_editor = new ShaderDialog( l_pass->GetEngine(), IsEditable(), NULL, l_pass );
+		ShaderDialog * l_editor = new ShaderDialog( l_pass->GetEngine(), IsEditable(), nullptr, l_pass );
 		l_editor->Show();
 		return false;
 	}

--- a/source/Samples/GuiCommon/Src/PropertiesHolder.cpp
+++ b/source/Samples/GuiCommon/Src/PropertiesHolder.cpp
@@ -38,12 +38,12 @@ using namespace Castor;
 
 namespace GuiCommon
 {
-	wxPGEditor * PropertiesHolder::m_buttonEditor = NULL;
+	wxPGEditor * PropertiesHolder::m_buttonEditor = nullptr;
 
 	PropertiesHolder::PropertiesHolder( bool p_bCanEdit, wxWindow * p_parent, wxPoint const & p_ptPos, wxSize const & p_size )
 		: wxPropertyGrid( p_parent, wxID_ANY, p_ptPos, p_size, wxPG_BOLD_MODIFIED | wxPG_SPLITTER_AUTO_CENTER | wxPG_DEFAULT_STYLE )
 		, m_bCanEdit( p_bCanEdit )
-		, m_data( NULL )
+		, m_data( nullptr )
 	{
 		if ( !m_buttonEditor )
 		{

--- a/source/Samples/GuiCommon/Src/Recorder.cpp
+++ b/source/Samples/GuiCommon/Src/Recorder.cpp
@@ -134,8 +134,8 @@ namespace GuiCommon
 		struct FFmpegFileWriter
 		{
 			FFmpegFileWriter()
-				: m_pAvCodecContext( NULL )
-				, m_pFile( NULL )
+				: m_pAvCodecContext( nullptr )
+				, m_pFile( nullptr )
 			{
 			}
 
@@ -162,7 +162,7 @@ namespace GuiCommon
 				{
 					avcodec_close( m_pAvCodecContext );
 					av_free( m_pAvCodecContext );
-					m_pAvCodecContext = NULL;
+					m_pAvCodecContext = nullptr;
 				}
 			}
 
@@ -182,7 +182,7 @@ namespace GuiCommon
 			bool Open( wxString const & p_name )
 			{
 				m_pFile = fopen( p_name.char_str().data(), "wb" );
-				return m_pFile != NULL;
+				return m_pFile != nullptr;
 			}
 
 			void Close()
@@ -190,7 +190,7 @@ namespace GuiCommon
 				if ( m_pFile )
 				{
 					fclose( m_pFile );
-					m_pFile = NULL;
+					m_pFile = nullptr;
 				}
 			}
 
@@ -201,8 +201,8 @@ namespace GuiCommon
 		struct FFmpegStreamWriter
 		{
 			FFmpegStreamWriter()
-				: m_pAvFormatContext( NULL )
-				, m_pAvStream( NULL )
+				: m_pAvFormatContext( nullptr )
+				, m_pAvStream( nullptr )
 			{
 			}
 
@@ -219,7 +219,7 @@ namespace GuiCommon
 
 			AVCodecContext * AllocateContext( AVCodec * p_codec, AVCodecID p_id )
 			{
-				AVCodecContext * pAvCodecContext = NULL;
+				AVCodecContext * pAvCodecContext = nullptr;
 				m_pAvStream = avformat_new_stream( m_pAvFormatContext, p_codec );
 
 				if ( m_pAvStream )
@@ -252,12 +252,12 @@ namespace GuiCommon
 
 			void PreOpen( wxString const & p_name )
 			{
-				avformat_alloc_output_context2( &m_pAvFormatContext, NULL, NULL, p_name.char_str().data() );
+				avformat_alloc_output_context2( &m_pAvFormatContext, nullptr, nullptr, p_name.char_str().data() );
 
 				if ( !m_pAvFormatContext )
 				{
 					//printf("Could not deduce output format from file extension: using MPEG.\n");
-					avformat_alloc_output_context2( &m_pAvFormatContext, NULL, "mpeg", p_name.char_str().data() );
+					avformat_alloc_output_context2( &m_pAvFormatContext, nullptr, "mpeg", p_name.char_str().data() );
 				}
 			}
 
@@ -276,7 +276,7 @@ namespace GuiCommon
 					}
 
 					avformat_free_context( m_pAvFormatContext );
-					m_pAvFormatContext = NULL;
+					m_pAvFormatContext = nullptr;
 				}
 			}
 
@@ -291,11 +291,11 @@ namespace GuiCommon
 		{
 		public:
 			FFmpegRecorderImpl()
-				: m_pAvCodec( NULL )
-				, m_pAvFrame( NULL )
-				, m_pAvCodecContext( NULL )
+				: m_pAvCodec( nullptr )
+				, m_pAvFrame( nullptr )
+				, m_pAvCodecContext( nullptr )
 			{
-				m_avEncodedPicture.data[0] = NULL;
+				m_avEncodedPicture.data[0] = nullptr;
 				av_register_all();
 			}
 
@@ -318,7 +318,7 @@ namespace GuiCommon
 
 					while ( l_iGotOutput )
 					{
-						int iRet = avcodec_encode_video2( m_pAvCodecContext, &l_pkt, NULL, &l_iGotOutput );
+						int iRet = avcodec_encode_video2( m_pAvCodecContext, &l_pkt, nullptr, &l_iGotOutput );
 
 						if ( iRet >= 0 && l_iGotOutput )
 						{
@@ -338,13 +338,13 @@ namespace GuiCommon
 				if ( m_avEncodedPicture.data[0] )
 				{
 					av_freep( &m_avEncodedPicture.data[0] );
-					m_avEncodedPicture.data[0] = NULL;
+					m_avEncodedPicture.data[0] = nullptr;
 				}
 
 				if ( m_pAvFrame )
 				{
 					av_frame_free( &m_pAvFrame );
-					m_pAvFrame = NULL;
+					m_pAvFrame = nullptr;
 				}
 
 				Writer::Close();
@@ -394,7 +394,7 @@ namespace GuiCommon
 				av_opt_set( m_pAvCodecContext->priv_data, "profile", "high", AV_OPT_SEARCH_CHILDREN );
 				av_opt_set( m_pAvCodecContext->priv_data, "level", "4,1", AV_OPT_SEARCH_CHILDREN );
 
-				if ( avcodec_open2( m_pAvCodecContext, m_pAvCodec, NULL ) < 0 )
+				if ( avcodec_open2( m_pAvCodecContext, m_pAvCodec, nullptr ) < 0 )
 				{
 					StopRecord();
 					throw std::runtime_error( ( char const * )wxString( _( "Could not open codec" ) ).mb_str( wxConvUTF8 ) );
@@ -426,13 +426,13 @@ namespace GuiCommon
 
 			virtual void DoRecordFrame( PxBufferBaseSPtr p_buffer )
 			{
-				static SwsContext * l_pSwsContext = NULL;
+				static SwsContext * l_pSwsContext = nullptr;
 
 				if ( !l_pSwsContext )
 				{
 					l_pSwsContext = sws_getContext( m_pAvCodecContext->width, m_pAvCodecContext->height, AV_PIX_FMT_RGBA,
 													m_pAvCodecContext->width, m_pAvCodecContext->height, m_pAvCodecContext->pix_fmt,
-													SWS_BICUBIC, NULL, NULL, NULL );
+													SWS_BICUBIC, nullptr, nullptr, nullptr );
 
 					if ( !l_pSwsContext )
 					{
@@ -518,17 +518,7 @@ namespace GuiCommon
 			{
 				if ( !m_writer.open( p_name.char_str().data(), MAKEFOURCC( 'X', '2', '6', '4' ), m_iWantedFPS, cv::Size( p_size.width(), p_size.height() ), true ) )
 				{
-#		if defined( _WIN32 )
-					wxMessageBox( _( "Can't open file with OpenCV, encoding: H264, please select another codec" ) );
-
-					if ( !m_writer.open( p_name.char_str().data(), -1, m_iWantedFPS, cv::Size( p_size.width(), p_size.height() ), true ) )
-					{
-						throw std::runtime_error( ( char const * )wxString( _( "Could not open file with OpenCV" ) ).mb_str( wxConvUTF8 ) );
-					}
-
-#		else
 					throw std::runtime_error( ( char const * )wxString( _( "Could not open file with OpenCV, encoding: H264" ) ).mb_str( wxConvUTF8 ) );
-#		endif
 				}
 
 				m_size = p_size;

--- a/source/Samples/GuiCommon/Src/SceneObjectsList.cpp
+++ b/source/Samples/GuiCommon/Src/SceneObjectsList.cpp
@@ -41,7 +41,7 @@ namespace GuiCommon
 {
 	SceneObjectsList::SceneObjectsList( PropertiesHolder * p_propertiesHolder, wxWindow * p_parent, wxPoint const & p_ptPos, wxSize const & p_size )
 		: wxTreeCtrl( p_parent, wxID_ANY, p_ptPos, p_size, wxTR_DEFAULT_STYLE | wxNO_BORDER )
-		, m_engine( NULL )
+		, m_engine( nullptr )
 		, m_propertiesHolder( p_propertiesHolder )
 	{
 		wxImage * l_icons[] =

--- a/source/Samples/GuiCommon/Src/SceneTreeItemProperty.cpp
+++ b/source/Samples/GuiCommon/Src/SceneTreeItemProperty.cpp
@@ -64,7 +64,7 @@ namespace GuiCommon
 
 	wxPGProperty * SceneTreeItemProperty::DoCreateTextureImageProperty( wxString const & p_name, Castor3D::TextureSPtr p_texture )
 	{
-		wxPGProperty * l_property = NULL;
+		wxPGProperty * l_property = nullptr;
 
 		if ( p_texture->GetBaseType() == eTEXTURE_BASE_TYPE_STATIC )
 		{

--- a/source/Samples/GuiCommon/Src/SplashScreen.cpp
+++ b/source/Samples/GuiCommon/Src/SplashScreen.cpp
@@ -12,7 +12,7 @@ using namespace Castor3D;
 using namespace Castor;
 
 SplashScreen::SplashScreen( wxString const & p_strTitle, wxPoint const & p_ptTitlePos, wxPoint const & p_ptCopyrightPos, wxPoint const & p_ptVersionPos, wxPoint p_ptPos, int p_iRange )
-	: wxFrame( NULL, wxID_ANY, p_strTitle, p_ptPos, wxSize( 512, 384 ), wxCLIP_CHILDREN | wxBORDER_NONE )
+	: wxFrame( nullptr, wxID_ANY, p_strTitle, p_ptPos, wxSize( 512, 384 ), wxCLIP_CHILDREN | wxBORDER_NONE )
 	, m_bmpSplash( splash_xpm )
 	, m_ptTitlePosition( p_ptTitlePos )
 	, m_ptCopyrightPosition( p_ptCopyrightPos )

--- a/source/Samples/GuiCommon/Src/TreeItemProperty.cpp
+++ b/source/Samples/GuiCommon/Src/TreeItemProperty.cpp
@@ -19,7 +19,7 @@ namespace GuiCommon
 		, m_type( p_type )
 		, m_editable( p_editable )
 		, m_engine( p_engine )
-		, m_menu( NULL )
+		, m_menu( nullptr )
 	{
 	}
 


### PR DESCRIPTION
Fixed asynchronous render loop cleanup (RenderSystem had to be cleaned up inside the loop's thread).

Replaced NULL by nullptr.
CastorApplication doesn't need /f (-f) to load a scene file anymore, so a cscn or zip file can be dropped on the .exe to be loaded through CastorViewer (Windows only).
Modified the Record and Print Screen functions, to make them work with asynchronous render loop.