### PR TITLE
Skybox are fixed.

### DIFF
--- a/source/Core/Castor3D/Src/Render/RenderLoop.cpp
+++ b/source/Core/Castor3D/Src/Render/RenderLoop.cpp
@@ -168,6 +168,10 @@ namespace Castor3D
 
 	void RenderLoop::DoCpuStep()
 	{
+		GetEngine()->GetFrameListenerCache().ForEach( []( FrameListener & p_listener )
+		{
+			p_listener.FireEvents( EventType::ePostRender );
+		} );
 		GetEngine()->GetSceneCache().ForEach( []( Scene & p_scene )
 		{
 			p_scene.Update();
@@ -175,10 +179,6 @@ namespace Castor3D
 		GetEngine()->GetRenderTechniqueCache().ForEach( []( RenderTechnique & p_technique )
 		{
 			p_technique.Update();
-		} );
-		GetEngine()->GetFrameListenerCache().ForEach( []( FrameListener & p_listener )
-		{
-			p_listener.FireEvents( EventType::ePostRender );
 		} );
 		GetEngine()->GetOverlayCache().Update();
 		m_debugOverlays->EndCpuTask();

--- a/source/Samples/CastorViewer/Src/MouseNodeEvent.cpp
+++ b/source/Samples/CastorViewer/Src/MouseNodeEvent.cpp
@@ -6,7 +6,7 @@ using namespace Castor;
 namespace CastorViewer
 {
 	MouseNodeEvent::MouseNodeEvent( SceneNodeSPtr p_node, real p_dx, real p_dy, real p_dz )
-		: FrameEvent( EventType::ePreRender )
+		: FrameEvent( EventType::ePostRender )
 		, m_node( p_node )
 		, m_dx( p_dx )
 		, m_dy( p_dy )


### PR DESCRIPTION
It was due to unsynchronised camera and skybox: The skybox is rendered before the scene is updated.
I've also had to modify the mouse events to make them post post-render events.